### PR TITLE
Bitget Futures Connector

### DIFF
--- a/Bitget (dziabko)/bitget-datahandler.ts
+++ b/Bitget (dziabko)/bitget-datahandler.ts
@@ -23,6 +23,10 @@ export function onMessage(data: Types.Serializable[]): void {
     });
 }
 
+export function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 // Example usage
 // const exampleData: Types.Serializable[] = [
 //     { id: 1, name: "Item 1" },

--- a/Bitget (dziabko)/bitget-datahandler.ts
+++ b/Bitget (dziabko)/bitget-datahandler.ts
@@ -1,0 +1,32 @@
+import * as Types from "./types"
+
+
+export function onMessage(data: Types.Serializable[]): void {
+    data.forEach(item => {
+        // Process each item
+        console.log("Processing item:", item);
+        // Add your processing logic here
+        const payload = JSON.parse(JSON.stringify(item));
+        if (payload.event === "subscribe") {
+            // Process the subscribed data
+            console.log("Processing BitgetTrade subscribed channels:", payload);
+        } else if (payload.channel === "orders") {
+            // Process the snapshot data
+            console.log("Processing BitgetTrade subscribed channels:", payload);
+        } else if (payload.channel === "account") {
+            // Process the snapshot data
+            console.log("Processing BitgetTrade Account Information:", payload);
+        } else {
+            // Process error
+            console.log("Error processing Serialized message");
+        }
+    });
+}
+
+// Example usage
+// const exampleData: Types.Serializable[] = [
+//     { id: 1, name: "Item 1" },
+//     { id: 2, name: "Item 2" }
+// ];
+
+// onMessage(exampleData);

--- a/Bitget (dziabko)/bitget-futures-private-connector.ts
+++ b/Bitget (dziabko)/bitget-futures-private-connector.ts
@@ -1,0 +1,612 @@
+// import {
+//     ConnectorConfiguration,
+//     ConnectorGroup,
+//     PrivateExchangeConnector,
+//     Serializable,
+//     SklEvent,
+//     Credential,
+//     OrderState,
+//     Side,
+//     OrderStatusUpdate,
+//     CancelOrdersRequest,
+//     OpenOrdersRequest,
+//     BalanceRequest,
+//     BalanceResponse,
+//     BatchOrdersRequest
+// } from "../../types";
+
+// import { Logger } from "../../util/logging";
+import * as Types from "./types";
+import CryptoJS from "crypto-js";
+import axios, { AxiosStatic } from "axios";
+import { WebSocket } from "ws";
+import {
+  getBitgetSymbol,
+  BitgetInvertedSideMap,
+  BitgetSideMap,
+  BitgetStringSideMap,
+} from "./bitget-spot";
+import { getSklSymbol } from "../../util/config";
+import "dotenv/config";
+import { error } from "console";
+// import { Serializable } from "child_process";
+
+export interface BitgetOrderProgress {
+  d: {
+    s: any;
+    S: any;
+    i: any;
+    c: any;
+    p: any;
+    v: any;
+    ap: any;
+    a: any;
+    t: any;
+  };
+  t: string;
+}
+
+export type BitgetOrderType = "limit" | "market";
+
+const BitgetWSOrderUpdateStateMap: { [key: string]: OrderState } = {
+  "1": "Placed",
+  "2": "Filled",
+  "3": "PartiallyFilled",
+  "4": "Cancelled",
+  "5": "CancelledPartiallyFilled",
+};
+
+const BitgetOpenOrdersStateMap: { [key: string]: OrderState } = {
+  NEW: "Placed",
+  PARTIALLY_FILLED: "PartiallyFilled",
+};
+
+const BitgetOrderTypeMap: { [key: string]: BitgetOrderType } = {
+  Limit: "limit",
+  Market: "market",
+};
+
+// const logger = Logger.getInstance('Bitget-spot-private-connector')
+
+export class BitgetFuturesPrivateConnector implements PrivateExchangeConnector {
+  public connectorId: string;
+
+  // public privateWebsocketAddress = 'wss://ws.bitget.com/spot/v1/stream';
+  public privateWebsocketAddress = "wss://ws.bitget.com/v2/ws/private";
+
+  public privateRestEndpoint = "https://api.bitget.com";
+  public publicRestEndpoint = "https://api.bitget.com";
+
+  // Keys & Passphrases necessary for websocket authentication & login
+  private apiKey = process.env.API_KEY || "";
+  private secretKey = process.env.SECRET_KEY || "";
+  private passphrase = process.env.PASSPHRASE || "";
+
+  public privateWSFeed: any;
+
+  private pingInterval: any;
+
+  private channelArguments: Types.channelRequest;
+
+  private axios: AxiosStatic;
+
+  private exchangeSymbol: string;
+
+  private sklSymbol: string;
+
+  constructor() {
+    const self = this;
+
+    // Define which channels to subscribe to
+    // Currently set to SUSDT-FUTURES channel for available demo trading USDT tokens
+    this.channelArguments = {
+      args: [
+        {
+          instType: "SUSDT-FUTURES",
+          channel: "account",
+          coin: "default",
+        },
+      ],
+    };
+
+    // this.channelArguments = {
+    //     args: [{
+    //         instType: "SUSDT-FUTURES",
+    //         channel: "orders",
+    //         instId: "default"
+    //     },
+    //     {
+    //         instType: "SUSDT-FUTURES",
+    //         channel: "positions",
+    //         instId: "default"
+    //     }]
+    // };
+
+    this.sklSymbol = "SKL";
+
+    self.axios = axios;
+  }
+
+  private startPingInterval(): void {
+    this.pingInterval = setInterval(() => {
+      this.privateWSFeed.send("ping");
+    }, 5000); // Ping every 30 seconds
+  }
+
+  private stopPingInterval(): void {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+    }
+  }
+
+  private async authenticate(): Promise<void> {
+    // Get the server timestamp
+    const timestamp = await this.getServerTimestamp();
+
+    // Create the signature necessary for websocket header login
+    const sign = CryptoJS.enc.Base64.stringify(CryptoJS.HmacSHA256(timestamp + "GET" + "/user/verify", this.secretKey));
+          
+    //   Login header for private websocket
+    const header = {
+    op: "login",
+    args: [
+        {
+        apiKey: this.apiKey,
+        passphrase: this.passphrase,
+        timestamp: timestamp,
+        sign: sign,
+        },
+    ],
+    };
+    
+    // Send the login message to the websocket
+    this.privateWSFeed.send(JSON.stringify(header));
+
+  }
+
+  public async connect(
+    onMessage: (m: Types.Serializable[]) => void,
+    socket = undefined
+  ): Promise<any> {
+    return new Promise(async (resolve) => {
+
+      this.privateWSFeed =
+        socket || new WebSocket(this.privateWebsocketAddress);
+
+      this.privateWSFeed.on("open", () => {
+        this.startPingInterval();
+
+        // Authenticate the websocket connection
+        this.authenticate();
+      });
+
+      this.privateWSFeed.onmessage = (message: { data: any }) => {
+        // PING/PONG response to keep the connection alive
+        if (message.data === "pong") {
+            return;
+        }
+
+        // Handle the incoming message
+        this.handleMessage(message.data.toString(), onMessage);
+
+        // Once we have successfully connected & logged into to the private WebSocket, we can subscribe to any private channel
+        let bitgetSocketMessage: Types.BitgetSocketMessage = JSON.parse(message.data.toString());
+
+        // If the message is a login response, subscribe to the private channels
+        if (bitgetSocketMessage.event == "login") {
+
+          // Once logged in, subscribe to the private channels
+          const subscriptionMessage = {
+            op: "subscribe",
+            args: this.channelArguments.args,
+          };
+          this.privateWSFeed.send(JSON.stringify(subscriptionMessage));
+        }
+      };
+
+      this.privateWSFeed.on("error", function error(err: any) {
+        // logger.log(`WebSocket error: ${err.toString()}`);
+      });
+
+      this.privateWSFeed.on("close", (code: any, reason: any) => {
+        this.stopPingInterval();
+        setTimeout(() => {
+          clearInterval(this.pingInterval);
+          this.connect(onMessage);
+        }, 1000);  // Reconnect after 1 second
+      });
+
+      if (this.privateWSFeed.__init !== undefined) {
+        this.privateWSFeed.__init();
+      }
+    });
+  }
+
+  public async stop(request: Types.OpenOrdersRequest): Promise<void> {
+    clearInterval(this.pingInterval);
+
+    // Unsubscribe from all channels
+    const unsubscribeMessage = JSON.stringify({
+        op: "unsubscribe",
+        args: this.channelArguments.args,
+      });
+
+    this.privateWSFeed.send(unsubscribeMessage);
+
+    // Close all active/open orders
+    let activeOrders = await this.getCurrentActiveOrders(request);
+    let cancelOrders: Types.CancelOrdersRequest[] = activeOrders.map((order) => {
+        return {
+            symbol: order.symbol,
+            productType: request.productType,
+            marginCoin: order.marginCoin,
+            orderId: order.orderId,
+            clientOid: order.clientOid,
+        }
+    });
+    let cancelOrderReq: Types.BatchCancelOrdersRequest = {
+        orderList: cancelOrders,
+    }
+
+    // Delete all the active orders
+    await this.deleteAllOrders(cancelOrderReq);
+
+    // Stop ping interval
+    this.stopPingInterval();
+    this.privateWSFeed.close();
+    return;
+    
+  }
+
+  private handleMessage(
+    data: string,
+    onMessage: (messages: Types.Serializable[]) => void
+  ): void {
+    let message = JSON.parse(data);
+
+    // Check if the message is a login response prior to handling message
+    if (message["event"] === "login" || message["event"] === "subscribe" || message["event"] === "unsubscribe") {
+      console.log("LOGIN/SUBSCRIBE SUCCESSFUL");
+      return;
+    }
+
+    // If the message is an error, log error message and return
+    if (message["event"] === "error") {
+      console.log("ERROR: ", message["error"]);
+      return;
+    }
+
+    const eventType = this.getEventType(message);
+
+    if (eventType === "OrderStatusUpdate") {
+      const orderStatusUpdate = this.createOrderStatusUpdate(eventType, message);
+      onMessage([orderStatusUpdate]);
+    } else if (eventType === "AllBalances") {
+      const balancesUpdate = this.createBalanceUpdate(eventType, message);
+      onMessage([balancesUpdate]);
+    } else {
+      // Handle unrecognized messages
+      console.log("Unrecognizable message: ", message);
+      return;
+    }
+  }
+
+  private subscribeToPrivateChannels(): void {
+    const subscriptionMessage = {
+      op: "subscribe",
+      args: this.channelArguments.args,
+    };
+
+    this.privateWSFeed.send(JSON.stringify(subscriptionMessage));
+    console.log("Subscribed to channels:", this.channelArguments.args);
+  }
+
+  public async getCurrentActiveOrders(
+    request: Types.OpenOrdersRequest
+  ): Promise<Types.OrderStatusUpdate[]> {
+    const activeOrdersResponse: Types.ActiveOrdersResponse = await this.getRequest("/api/v2/mix/order/orders-pending", request);
+    console.log("ACTIVE ORDERS: ", activeOrdersResponse);
+
+    // If no active orders, return an empty update
+    if (activeOrdersResponse.data.entrustedList == null) {
+        return [];
+    }
+
+    // Map the active/open orders to an array of OrderStatusUpdate
+    return activeOrdersResponse.data.entrustedList.map((activeOrder) => ({
+      event: "OrderStatusUpdate",
+      connectorType: "Bitget",
+      symbol: activeOrder.symbol,
+      orderId: activeOrder.orderId,
+      state: activeOrder.status,
+      side: activeOrder.side,
+      price: parseFloat(activeOrder.price),
+      size: activeOrder.size,
+      notional: parseFloat(activeOrder.price) * parseFloat(activeOrder.size),
+      timestamp: activeOrder.cTime,
+      clientOid: activeOrder.clientOid,
+      fee: activeOrder.fee,
+      priceAvg: activeOrder.priceAvg,
+      status: activeOrder.status,
+      force: activeOrder.force,
+      totalProfits: activeOrder.totalProfits,
+      marginCoin: activeOrder.marginCoin,
+      marginMode: activeOrder.marginMode,
+      posMode: activeOrder.posMode,
+      posSide: activeOrder.posSide,
+      quoteVolume: activeOrder.quoteVolume,
+      leverage: activeOrder.leverage,
+      enterPointSource: activeOrder.enterPointSource,
+      tradeSide: activeOrder.tradeSide,
+      orderType: activeOrder.orderType,
+      orderSource: activeOrder.orderSource,
+      presetStopSurplusPrice: activeOrder.presetStopSurplusPrice,
+      presetStopLossPrice: activeOrder.presetStopLossPrice,
+      reduceOnly: activeOrder.reduceOnly,
+      cTime: activeOrder.cTime,
+      uTime: activeOrder.uTime,
+    }));
+  }
+
+  //   Getting the percentage of the available balance to the account's total equity which involves (balance, open orders, and positions)
+  public async getBalancePercentage(
+    request: Types.BalanceRequest
+  ): Promise<Types.BalanceResponse> {
+    const self = this;
+    const result: Types.AccountResponse = await this.getRequest("/api/v2/mix/account/accounts", request);
+
+    // Calculate inventoryPercentage
+    const baseVal = parseFloat(result.data[0].maxTransferOut);
+    const usdtValue = parseFloat(result.data[0].usdtEquity);
+    const inventoryPercentage = (baseVal / usdtValue) * 100;
+
+    return {
+      event: "BalanceResponse",
+      symbol: result.data[0].marginCoin,
+      baseBalance: baseVal,
+      inventory: inventoryPercentage,
+      timestamp: result.requestTime,
+    };
+  }
+
+  public async placeOrders(request: Types.BatchFuturesLimitOrdersRequest): Promise<any> {
+    const self = this;
+    const orders = request.orderList.map((order) => {
+      return {
+        symbol: request.symbol,
+        productType: request.productType,
+        marginCoin: request.marginCoin,
+        marginMode: request.marginMode,
+        price: order.price,
+        size: order.size,
+        side: order.side,
+        orderType: order.orderType,
+        force: order.force,
+      };
+    });
+
+    const responses1: Promise<Types.FuturesLimitOrderResponse>[] = orders.map(
+      async (order) => {
+        console.log("Placing order: ", order);
+        const res: Promise<Types.FuturesLimitOrderResponse> = this.postRequest(
+          "/api/v2/mix/order/place-order",
+          order
+        );
+        return res;
+      }
+    );
+    return responses1;
+  }
+
+  public async deleteAllOrders(
+    request: Types.BatchCancelOrdersRequest
+  ): Promise<any> {
+    const orders = request.orderList.map((order) => {
+      return {
+        symbol: order.symbol,
+        productType: order.productType,
+        marginCoin: order.marginCoin,
+        orderId: order.orderId,
+        clientOid: order.clientOid,
+      };
+    });
+
+    // Perform a cancel-order request on each order in the batch
+    const responses1: Promise<Types.FuturesLimitOrderResponse>[] = orders.map(
+      async (order) => {
+        console.log("Cancelling order: ", order);
+        const res: Promise<Types.FuturesLimitOrderResponse> = this.postRequest(
+          "/api/v2/mix/order/cancel-order",
+          order
+        );
+        return res;
+      }
+    );
+    return responses1;
+  }
+
+  private getEventType(message: any): Types.SklEvent | null {
+    if (message.arg.channel === "account") {
+      return "AllBalances";
+    } else if (message.arg.channel === "orders") {
+      return "OrderStatusUpdate";
+    } else if (message.op === "subscription") {
+      console.info(`Subscription confirmed: ${JSON.stringify(message)}`);
+      return null;
+    } else if (message.event === "error") {
+      console.error(`Error message received: ${message.error}`);
+      return null;
+    }
+    return null;
+  }
+
+  private createSklEvent(
+    event: Types.SklEvent,
+    message: any
+  ): Types.Serializable[] {
+    if (event === "OrderStatusUpdate") {
+      return [this.createOrderStatusUpdate(event, message)];
+    } else if (event === "AllBalances") {
+      return [this.createBalanceUpdate(event, message)];
+    } else {
+      return [];
+    }
+  }
+
+  private createOrderStatusUpdate(action: Types.SklEvent, order: Types.BitgetSnapshot): Types.Serializable {
+    return {
+      event: order.action,
+      channel: order.arg.channel,
+      instType: order.arg.instType,
+      accBaseVolume: parseFloat(order.data[0].accBaseVolume),
+      cTime: parseInt(order.data[0].cTime),
+      clientOid: parseInt(order.data[0].clientOId),
+      enterPointSource: order.data[0].enterPointSource,
+      feeDetail: [
+        {
+          feeCoin: order.data[0].feeDetail[0].feeCoin,
+          fee: parseFloat(order.data[0].feeDetail[0].fee),
+        },
+      ],
+      force: order.data[0].force,
+      instId: order.data[0].instId,
+      leverage: parseInt(order.data[0].leverage),
+      marginCoin: order.data[0].marginCoin,
+      marginMode: order.data[0].marginMode,
+      notionalUsd: parseFloat(order.data[0].notionalUsd),
+      orderId: parseInt(order.data[0].orderId),
+      orderType: order.data[0].orderType,
+      posMode: order.data[0].posMode,
+      posSide: order.data[0].posSide,
+      price: parseFloat(order.data[0].price),
+      reduceOnly: order.data[0].reduceOnly,
+      side: order.data[0].side,
+      size: parseFloat(order.data[0].size),
+      status: order.data[0].status,
+      stpMode: order.data[0].stpMode,
+      tradeSide: order.data[0].tradeSide,
+      uTime: parseInt(order.data[0].uTime),
+    };
+  }
+  private createBalanceUpdate(action: Types.SklEvent, order: Types.BitgetAccountSnapshot): Types.Serializable {
+    return {
+      event: order.action,
+      channel: order.arg.channel,
+      instType: order.arg.instType,
+      marginCoin: order.data[0].marginCoin,
+      frozen: order.data[0].frozen,
+      available: order.data[0].available,
+      maxOpenPosAvailable: order.data[0].maxOpenPosAvailable,
+      maxTransferOut: order.data[0].maxTransferOut,
+      equity: order.data[0].equity,
+      usdtEquity: order.data[0].usdtEquity,
+      timestamp: order.data[0].timestamp,
+    };
+  }
+
+  //   Get the serverTimestamp if possible, otherwise return the local system's timestamp
+  private async getServerTimestamp(): Promise<number> {
+    let result;
+    try {
+      // Get timestamp from server using REST API
+      result = await axios.get(`${this.publicRestEndpoint}/api/v2/public/time`);
+    } catch (error) {
+      console.log(error);
+      // Upon failed request, return local system's timestamp
+      return Date.now() / 1000;
+    }
+    if (result.data.requestTime) {
+      return result.data.requestTime;
+    } else {
+      return Date.now() / 1000;
+    }
+  }
+
+  private jsonToQueryString(json: Record<string, any>): string {
+    return Object.keys(json)
+      .map(
+        (key) => `${encodeURIComponent(key)}=${encodeURIComponent(json[key])}`
+      )
+      .join("&");
+  }
+
+  private async getRequest(route: string, queryParam: any): Promise<any> {
+    const now = Date.now();
+
+    // Get the server timestamp & Message for signature
+    let timestamp = await this.getServerTimestamp();
+    const queryString =
+      queryParam !== undefined ? this.jsonToQueryString(queryParam) : "";
+    const Message = timestamp + "GET" + route + "?" + queryString;
+    const payload = CryptoJS.HmacSHA256(Message, this.secretKey);
+    const signature = CryptoJS.enc.Base64.stringify(payload);
+
+    const header = {
+      "Content-Type": "application/json",
+      "ACCESS-KEY": this.apiKey,
+      "ACCESS-SIGN": signature,
+      "ACCESS-PASSPHRASE": this.passphrase,
+      "ACCESS-TIMESTAMP": timestamp,
+      local: "en-US",
+    };
+
+    try {
+      const result = await this.axios.get(
+        `${this.privateRestEndpoint}${route}?${queryString}`,
+        {
+          headers: header,
+        });
+
+      return result.data;
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  private async postRequest(route: string, body: any): Promise<any> {
+    const now = new Date().getTime();
+
+    // Get the server timestamp & Message for signature
+    let timestamp = await this.getServerTimestamp();
+    const bodyData = body !== undefined ? JSON.stringify(body) : "";
+    const Message = timestamp + "POST" + route + bodyData;
+    const payload = CryptoJS.HmacSHA256(Message, this.secretKey);
+
+    // Signature calculation for header
+    const signature = CryptoJS.enc.Base64.stringify(payload);
+
+    const header = {
+      "Content-Type": "application/json",
+      "ACCESS-KEY": this.apiKey,
+      "ACCESS-SIGN": signature,
+      "ACCESS-PASSPHRASE": this.passphrase,
+      "ACCESS-TIMESTAMP": timestamp,
+      local: "en-US",
+    };
+
+    try {
+      const result = await this.axios.post(
+        `${this.publicRestEndpoint}${route}`,
+        bodyData,
+        {
+          headers: header,
+        }
+      );
+
+      return result.data;
+    } catch (error) {
+      console.log(`POST Error: ${error}`);
+    }
+  }
+
+  private chunkArray(array: string | any[], chunkSize: number): any {
+    const chunks = [];
+
+    for (let i = 0; i < array.length; i += chunkSize) {
+      chunks.push(array.slice(i, i + chunkSize));
+    }
+
+    return chunks;
+  }
+}

--- a/Bitget (dziabko)/bitget-futures-public-connector.ts
+++ b/Bitget (dziabko)/bitget-futures-public-connector.ts
@@ -27,7 +27,7 @@ export interface BitgetMarketDepth {
 
 // export interface BitgetTrade { p: string, S: number, v: string, t: number };
 
-export class BitgetSpotPublicConnector implements PublicExchangeConnector {
+export class BitgetFuturesPublicConnector implements PublicExchangeConnector {
 
     public publicWebsocketAddress = 'wss://ws.bitget.com/spot/v1/stream';
     // public publicWebsocketAddress = 'wss://ws.bitget.com/v2/ws/public';

--- a/Bitget (dziabko)/bitget-futures-public-connector.ts
+++ b/Bitget (dziabko)/bitget-futures-public-connector.ts
@@ -1,0 +1,353 @@
+import * as Types from "./types"
+// import { ConnectorConfiguration, ConnectorGroup, PublicExchangeConnector, Serializable, SklEvent, Ticker, TopOfBook, Trade } from "../../types";
+// import { Serializable } from "child_process";
+// import { getSklSymbol } from "../../util/config";
+// import { Logger } from "../../util/logging";
+import { getBitgetSymbol, BitgetSideMap } from "./bitget-spot";
+import { WebSocket } from 'ws'
+
+// const logger = Logger.getInstance('Bitget-spot-public-connector');
+
+export interface BitgetMarketDepth {
+    d: {
+        asks: Array<{ p: string, v: string }>;
+        bids: Array<{ p: string, v: string }>;
+    }
+    s: string;
+    t: number;
+}
+
+// export interface BitgetTradeMessage {
+//     s: string;
+//     d: {
+//         deals: Array<BitgetTrade>
+//     }
+//     t: number;
+// }
+
+// export interface BitgetTrade { p: string, S: number, v: string, t: number };
+
+export class BitgetSpotPublicConnector implements PublicExchangeConnector {
+
+    public publicWebsocketAddress = 'wss://ws.bitget.com/spot/v1/stream';
+    // public publicWebsocketAddress = 'wss://ws.bitget.com/v2/ws/public';
+
+    private retryCount = 0;
+    public publicWSFeed: any;
+
+    private pingInterval: any;
+
+    // private exchangeSymbol: string;
+    private channelArguments: Types.channelRequest;
+    // =  {
+    //     instType: "SP",
+    //     channel: "candle1m",
+    //     instId: "BTC-USDT",
+    //     };
+
+    private sklSymbol: string;
+
+    constructor() {
+    // constructor(private group: ConnectorGroup, private config: ConnectorConfiguration) {
+        // const self = this
+        // self.exchangeSymbol = getBitgetSymbol(self.group, self.config);
+
+        // Define which channels to subscribe to
+        this.channelArguments = {
+            args: [{
+                instType: "sp",
+                channel: "trade",
+                instId: "ETHUSDT",
+            }],
+        };
+        this.sklSymbol = "SKL";
+        // self.sklSymbol = getSklSymbol(self.group, self.config);
+
+    }
+
+    public async connect(onMessage: (m: Types.Serializable[]) => void, socket = undefined): Promise<any> {
+    // public async connect(socket = undefined): Promise<any> {
+
+        return new Promise(async (resolve, reject) => {
+
+            console.log(`Attempting to connect to Bitget`);
+
+            const url = this.publicWebsocketAddress;
+
+            this.publicWSFeed = socket || new WebSocket(url);
+
+            this.publicWSFeed.on('open', () => {
+                try {
+                    // Hardcoding values for now but this can be obtained via props
+                    setTimeout(() => {
+                        // Hardcoding values for now but this can be obtained via props
+                        this.subscribeToChannels()
+                    }, 1000)
+                    this.retryCount = 0;
+                } catch (err) {
+                    console.error(`Error while connecting to WebSocket: ${err}`);
+                }
+                // try {
+
+                // const message = JSON.stringify({
+                //     'method': 'SUBSCRIPTION',
+                //     'params': [
+                //         `spot@public.deals.v3.api@${this.exchangeSymbol}`,
+                //         `spot@public.limit.depth.v3.api@${this.exchangeSymbol}@5`,
+                //         `spot@public.miniTicker.v3.api@${this.exchangeSymbol}@UTC+0`
+                //     ]
+                // });
+
+                // this.publicWSFeed.send(message);
+
+                // this.pingInterval = setInterval(() => {
+
+                //     console.log('Pinging Bitget');
+
+                //     this.publicWSFeed.send(JSON.stringify({
+                //         "method": "PING"
+                //     }));
+
+                // }, 1000 * 10)
+
+                // resolve(true);
+                // } catch (err: any) {
+                //     logger.error(`Error during WebSocket open event: ${err.message}`);
+                //     reject(err);
+                // }
+            }
+            );
+
+            this.publicWSFeed.onmessage = (message: { data: any; }) => {
+
+                try {
+                    console.log(1)
+                    const data = JSON.parse(message.data);
+                    console.log(2)
+                    const actionType: Types.SklEvent | null = this.getEventType(data)
+                    console.log(3)
+                    this.handleMessage(data, onMessage)
+                    console.log(4)
+                } catch (err) {
+                    console.error(`Error processing WebSocket message: ${err}`);
+                }
+
+            }
+
+            this.publicWSFeed.on('error', function error(err: any) {
+                console.log(`WebSocket error: ${err.toString()}`);
+            });
+
+            this.publicWSFeed.on('close', (code: any, reason: any) => {
+
+                console.log(`WebSocket closed: ${code} - ${reason}`);
+
+                setTimeout(() => {
+
+                    clearInterval(this.pingInterval);
+
+                    this.connect(onMessage)
+
+                }, 1000);
+
+            });
+
+            if (this.publicWSFeed.__init !== undefined) {
+
+                this.publicWSFeed.__init();
+
+            }
+
+        });
+
+    }
+
+    public async stop() {
+        clearInterval(this.pingInterval);
+
+        const message = {
+            op: "unsubscribe",
+            args: this.channelArguments.args,
+        };
+
+        this.publicWSFeed.send(JSON.stringify(message));
+        this.publicWSFeed.close();
+    }
+
+
+    private subscribeToChannels(): void {
+
+        const subscriptionMessage = {
+            op: 'subscribe',
+            args: this.channelArguments.args,
+        };
+
+        this.publicWSFeed.send(JSON.stringify(subscriptionMessage));
+        console.log('Subscribed to channels:', this.channelArguments.args);
+    }
+
+    private handleMessage(data: string, onMessage: (messages: Types.Serializable[]) => void): void {
+        console.log("HandleMessage1");
+        console.log("DATA: ", data);
+        var message;
+        try {
+            message = JSON.parse(JSON.stringify(data));
+        } catch (error) {
+            console.error("Failed to parse JSON:", error);
+            console.log("DATA: ", data);
+            return;
+        }
+        console.log("HandleMessage2");
+        const eventType = this.getEventType(message);
+        console.log("EVENTTYPE: ", eventType);
+        console.log("HandleMessage3");
+    
+        if (eventType) {
+            const serializableMessages = this.createSerializableEvents(eventType, message);
+            if (serializableMessages.length > 0) {
+                console.log("onMessage(serializableMessages)");
+                console.log(serializableMessages);
+                onMessage(serializableMessages);
+            }
+        } else {
+            // Log unrecognized messages
+        }
+    }
+
+    private createSerializableEvents(eventType: Types.SklEvent, eventData: Types.BitgetEventData): Types.Serializable[] {
+        switch (eventType) {
+            case 'Trade': {
+                // const trade = ({
+                //     ts: eventData.data[0][0],
+                //     px: eventData.data[0][1],
+                //     sz: eventData.data[0][2],
+                //     side: eventData.data[0][3],
+                // })
+                // const trades = trade as unknown as Types.BitgetTrade
+
+                //TODO: Iterate over data array
+                const trade: Types.BitgetTrade = {
+                    instType: eventData.arg.instType,
+                    channel: eventData.arg.channel,
+                    instId: eventData.arg.instId,
+                    timestamp: Number(eventData.data[0][0]),
+                    price: eventData.data[0][1],
+                    size: eventData.data[0][2],
+                    side: eventData.data[0][3]
+                }
+                //  eventData.params.data as unknown as Types.BitgetTrade[]
+                // return trade.map((trade: Types.BitgetTrade) => this.createTrade(trade)).filter((trade) => trade !== null)
+                return [this.createTrade(trade)].filter((e) => e !== null);
+            }
+            case 'Ticker': {
+                const ticker = eventData.params.data as unknown as Types.BitgetTicker
+                return [this.createTicker(ticker)].filter((e) => e !== null);
+            }
+            default:
+                return [];
+        }
+    }
+
+    private getEventType(message: any): Types.SklEvent | null {
+        if (message.arg.channel === 'trade') {
+            return 'Trade';
+        }  else if (message.arg.channel === 'ticker') {
+            return 'Ticker';
+        } else if (message.op === 'subscription') {
+            console.info(`Subscription confirmed: ${JSON.stringify(message)}`);
+            return null;
+        } else if (message.event === 'error') {
+            console.error(`Error message received: ${message.error}`);
+            return null;
+        }
+        return null;
+    }
+
+    // private createSklEvent(event: SklEvent, message: any, group: ConnectorGroup): Serializable[] {
+
+    //     if (event === 'TopOfBook') {
+
+    //         return [this.createTopOfBook(message, group)]
+
+    //     }
+    //     else if (event === 'Trade') {
+
+    //         const trades = message.d.deals.sort((a: BitgetTrade, b: BitgetTrade) => b.t - a.t)
+
+    //         return trades.map((trade: BitgetTrade) => this.createTrade(trade, group))
+
+    //     } else if (event === 'Ticker') {
+
+    //         return [this.createTicker(message, group)]
+
+    //     } else {
+
+    //         return []
+
+    //     }
+    // }
+
+    private createTopOfBook(marketDepth: BitgetMarketDepth, group: ConnectorGroup): TopOfBook {
+        return {
+            symbol: this.sklSymbol,
+            connectorType: 'Bitget',
+            event: 'TopOfBook',
+            timestamp: marketDepth.t,
+            askPrice: parseFloat(marketDepth.d.asks[0].p),
+            askSize: parseFloat(marketDepth.d.asks[0].v),
+            bidPrice: parseFloat(marketDepth.d.bids[0].p),
+            bidSize: parseFloat(marketDepth.d.bids[0].v),
+        };
+    }
+
+    private createTicker(ticker: Types.BitgetTicker): Ticker {
+        return {
+            event: 'Ticker',
+            connectorType: 'Bitget',
+            symbol: ticker.arg.instId,
+            lastPrice: parseFloat(ticker.data[0].last),
+            timestamp: ticker.data[0].ts * 1000,
+        };
+    }
+
+    private createTrade(trade: Types.BitgetTrade): Types.SklTrade | null {
+        console.log("createTrade");
+        console.log(trade);
+        const tradeSide: string | undefined = trade.side
+        if (tradeSide) {
+            return {
+                event: 'Trade',
+                connectorType: 'Bitget',
+                symbol: trade.instId,
+                price: Number(trade.price),
+                size: Number(trade.size),
+                side: BitgetSideMap[trade.side],
+                timestamp: (new Date(trade.timestamp)).getTime(),
+            }
+        } else {
+            return null
+        }
+    }
+
+    // private createTrade(trade: BitgetTrade, group: ConnectorGroup): Trade | null {
+
+    //     const tradeSide: number | undefined = trade.S;
+
+    //     if (tradeSide) {
+    //         return {
+    //             symbol: this.sklSymbol,
+    //             connectorType: 'Bitget',
+    //             event: 'Trade',
+    //             price: parseFloat(trade.p),
+    //             size: parseFloat(trade.v),
+    //             side: BitgetSideMap[tradeSide],
+    //             timestamp: trade.t * 1000,
+    //         }
+    //     } else {
+
+    //         return null;
+
+    //     }
+    // }
+
+}

--- a/Bitget (dziabko)/bitget-spot-datahandler.js
+++ b/Bitget (dziabko)/bitget-spot-datahandler.js
@@ -1,0 +1,29 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.onMessage = onMessage;
+function onMessage(data) {
+    data.forEach(item => {
+        // Process each item
+        console.log("Processing item:", item);
+        // Add your processing logic here
+        const payload = JSON.parse(JSON.stringify(item));
+        if (payload.event === "Trade") {
+            // Process the BitgetTrade data
+            console.log("Processing BitgetTrade data:", payload);
+        }
+        else if (payload.event === "Ticker") {
+            // Process the BitgetTicker data
+            console.log("Processing BitgetTicker data:", payload);
+        }
+        else {
+            // Process error
+            console.log("Error processing Serialized message");
+        }
+    });
+}
+// Example usage
+// const exampleData: Types.Serializable[] = [
+//     { id: 1, name: "Item 1" },
+//     { id: 2, name: "Item 2" }
+// ];
+// onMessage(exampleData);

--- a/Bitget (dziabko)/bitget-spot-datahandler.ts
+++ b/Bitget (dziabko)/bitget-spot-datahandler.ts
@@ -1,0 +1,29 @@
+import * as Types from "./types"
+
+
+export function onMessage(data: Types.Serializable[]): void {
+    data.forEach(item => {
+        // Process each item
+        console.log("Processing item:", item);
+        // Add your processing logic here
+        const payload = JSON.parse(JSON.stringify(item));
+        if (payload.event === "Trade") {
+            // Process the BitgetTrade data
+            console.log("Processing BitgetTrade data:", payload);
+        } else if (payload.event === "Ticker") {
+            // Process the BitgetTicker data
+            console.log("Processing BitgetTicker data:", payload);
+        } else {
+            // Process error
+            console.log("Error processing Serialized message");
+        }
+    });
+}
+
+// Example usage
+// const exampleData: Types.Serializable[] = [
+//     { id: 1, name: "Item 1" },
+//     { id: 2, name: "Item 2" }
+// ];
+
+// onMessage(exampleData);

--- a/Bitget (dziabko)/bitget-spot-private-connector.js
+++ b/Bitget (dziabko)/bitget-spot-private-connector.js
@@ -1,0 +1,366 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.BitgetSpotPrivateConnector = void 0;
+const logging_1 = require("../../util/logging");
+const crypto_js_1 = __importDefault(require("crypto-js"));
+const axios_1 = __importDefault(require("axios"));
+const ws_1 = require("ws");
+const bitget_spot_1 = require("./bitget-spot");
+const config_1 = require("../../util/config");
+const BitgetWSOrderUpdateStateMap = {
+    '1': 'Placed',
+    '2': 'Filled',
+    '3': 'PartiallyFilled',
+    '4': 'Cancelled',
+    '5': 'CancelledPartiallyFilled',
+};
+const BitgetOpenOrdersStateMap = {
+    'NEW': 'Placed',
+    'PARTIALLY_FILLED': 'PartiallyFilled',
+};
+const BitgetOrderTypeMap = {
+    'Limit': 'LIMIT',
+    'Market': 'MARKET',
+    'LimitMaker': 'LIMIT_MAKER',
+    'ImmediateOrCancel': 'IMMEDIATE_OR_CANCEL'
+};
+const logger = logging_1.Logger.getInstance('Bitget-spot-private-connector');
+class BitgetSpotPrivateConnector {
+    constructor(group, config, credential) {
+        this.group = group;
+        this.config = config;
+        this.credential = credential;
+        this.privateWebsocketAddress = 'wss://ws.bitget.com/v2/ws/private';
+        this.privateRestEndpoint = 'https://api.Bitget.com/api/v3';
+        const self = this;
+        self.exchangeSymbol = (0, bitget_spot_1.getBitgetSymbol)(self.group, self.config);
+        self.sklSymbol = (0, config_1.getSklSymbol)(self.group, self.config);
+        self.axios = axios_1.default;
+    }
+    connect(onMessage_1) {
+        return __awaiter(this, arguments, void 0, function* (onMessage, socket = undefined) {
+            return new Promise((resolve) => __awaiter(this, void 0, void 0, function* () {
+                const key = yield this.safeGetListenKey();
+                const url = this.privateWebsocketAddress + `?listenKey=${key.listenKey}`;
+                this.privateWSFeed = socket || new ws_1.WebSocket(url);
+                this.privateWSFeed.on('open', () => {
+                    const message = JSON.stringify({
+                        'method': 'SUBSCRIPTION',
+                        'params': [
+                            'spot@private.deals.v3.api',
+                            'spot@private.orders.v3.api'
+                        ]
+                    });
+                    this.privateWSFeed.send(message);
+                    this.pingInterval = setInterval(() => {
+                        console.log('Pinging Bitget');
+                        this.privateWSFeed.send(JSON.stringify({
+                            "method": "PING"
+                        }));
+                    }, 1000 * 10);
+                    resolve(true);
+                });
+                this.privateWSFeed.onmessage = (message) => {
+                    const data = JSON.parse(message.data);
+                    const actionType = this.getEventType(data);
+                    if (actionType) {
+                        const serializableMessages = this.createSklEvent(actionType, data, this.group);
+                        onMessage(serializableMessages);
+                    }
+                    else {
+                        logger.log(`No handler for message: ${JSON.stringify(data)}`);
+                    }
+                };
+                this.privateWSFeed.on('error', function error(err) {
+                    logger.log(`WebSocket error: ${err.toString()}`);
+                });
+                this.privateWSFeed.on('close', (code, reason) => {
+                    logger.log(`WebSocket closed: ${code} - ${reason}`);
+                    setTimeout(() => {
+                        clearInterval(this.pingInterval);
+                        this.connect(onMessage);
+                    }, 1000);
+                });
+                if (this.privateWSFeed.__init !== undefined) {
+                    this.privateWSFeed.__init();
+                }
+            }));
+        });
+    }
+    stop() {
+        return __awaiter(this, arguments, void 0, function* (cancelOrders = true) {
+            clearInterval(this.pingInterval);
+            const message = JSON.stringify({
+                'op': 'UNSUBSCRIPTION',
+                'params': [
+                    'spot@private.deals.v3.api',
+                    'spot@private.orders.v3.api'
+                ]
+            });
+            this.privateWSFeed.send(message);
+            if (cancelOrders === true && this.exchangeSymbol !== undefined) {
+                const event = 'CancelOrdersRequest';
+                return yield this.deleteAllOrders({
+                    connectorType: this.config.connectorType,
+                    event,
+                    symbol: this.exchangeSymbol,
+                    timestamp: new Date().getTime(),
+                });
+            }
+        });
+    }
+    getCurrentActiveOrders(request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const orders = yield this.getRequest('/openOrders', {
+                symbol: this.exchangeSymbol
+            });
+            logger.log(`RPC Response: OpenOrdersResponse -> ${JSON.stringify(orders)}`);
+            if (orders !== undefined) {
+                return orders.map((o) => {
+                    return {
+                        event: 'OrderStatusUpdate',
+                        connectorType: 'Bitget',
+                        symbol: this.sklSymbol,
+                        orderId: o.orderId,
+                        sklOrderId: o.clientOrderId,
+                        state: BitgetOpenOrdersStateMap[o.status],
+                        side: bitget_spot_1.BitgetStringSideMap[o.side],
+                        price: parseFloat(o.price),
+                        size: parseFloat(o.origQty),
+                        notional: parseFloat(o.price) * parseFloat(o.origQty),
+                        filled_price: parseFloat(o.price),
+                        filled_size: parseFloat(o.executedQty),
+                        timestamp: o.time
+                    };
+                });
+            }
+            return [];
+        });
+    }
+    getBalancePercentage(request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const self = this;
+            const result = yield this.getRequest('/account', {});
+            const baseAsset = self.group.name;
+            const quoteAsset = self.config.quoteAsset;
+            console.log(baseAsset);
+            const usdt = result.balances.find(d => d.asset === quoteAsset) || { free: 0, locked: 0 };
+            const base = result.balances.find(d => d.asset === baseAsset) || { free: 0, locked: 0 };
+            const baseVal = parseFloat(base.free) + parseFloat(base.locked);
+            const baseValue = parseFloat((baseVal * request.lastPrice));
+            const usdtValue = parseFloat(usdt.free) + parseFloat(usdt.locked);
+            const whole = parseFloat(baseValue) + usdtValue;
+            const pairPercentage = (baseValue / whole) * 100;
+            return {
+                event: "BalanceRequest",
+                symbol: this.sklSymbol,
+                baseBalance: baseVal,
+                quoteBalance: usdtValue,
+                inventory: pairPercentage,
+                timestamp: new Date().getTime()
+            };
+        });
+    }
+    placeOrders(request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const self = this;
+            const orders = request.orders.map(o => {
+                const side = bitget_spot_1.BitgetInvertedSideMap[o.side];
+                const type = BitgetOrderTypeMap[o.type];
+                return {
+                    symbol: self.exchangeSymbol,
+                    quantity: o.size.toFixed(8),
+                    price: o.price.toFixed(8),
+                    side,
+                    type,
+                };
+            });
+            const batches = this.chunkArray(orders, 20);
+            const pArray = batches.map(batch => {
+                return this.postRequest('/batchOrders', {
+                    batchOrders: JSON.stringify(batch)
+                });
+            });
+            const [completedBatches] = yield Promise.all(pArray);
+            logger.log(`Place order result: ${JSON.stringify(completedBatches)}`);
+            if (completedBatches.find(b => b.code !== undefined)) {
+                return Promise.reject(`At least one order in batch failed: ${JSON.stringify(completedBatches)}`);
+            }
+            else {
+                return completedBatches;
+            }
+        });
+    }
+    deleteAllOrders(request) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const self = this;
+            return yield self.deleteRequest('/openOrders', {
+                symbol: self.exchangeSymbol
+            });
+        });
+    }
+    getEventType(message) {
+        if ('code' in message && 'msg' in message) {
+            logger.log(`Subscription response: ${message.code} - ${message.msg}`);
+            return null;
+        }
+        else if ('c' in message) {
+            if (message.c.startsWith('spot@private.orders.v3.api')) {
+                return 'OrderStatusUpdate';
+            }
+        }
+        else {
+            return null;
+        }
+    }
+    createSklEvent(event, message, group) {
+        if (event === 'OrderStatusUpdate') {
+            return [this.createOrderStatusUpdate(event, message, group)];
+        }
+        else {
+            return [];
+        }
+    }
+    createOrderStatusUpdate(action, order, group) {
+        const state = BitgetWSOrderUpdateStateMap[order.d.s];
+        const side = bitget_spot_1.BitgetSideMap[order.d.S];
+        return {
+            symbol: this.sklSymbol,
+            connectorType: 'Bitget',
+            event: action,
+            state,
+            orderId: order.d.i,
+            sklOrderId: order.d.c,
+            side,
+            price: parseFloat(order.d.p),
+            size: order.d.v,
+            notional: parseFloat(order.d.p) * parseFloat(order.d.v),
+            filled_price: parseFloat(order.d.ap),
+            filled_size: parseFloat(order.d.a),
+            timestamp: parseInt(order.t)
+        };
+    }
+    safeGetListenKey() {
+        return __awaiter(this, void 0, void 0, function* () {
+            const keys = yield this.getRequest('/userDataStream', {});
+            console.log('Roating Keys, found', keys);
+            if (keys && keys.listenKey !== undefined) {
+                for (const key of keys.listenKey) {
+                    yield this.deleteRequest('/userDataStream', { listenKey: key });
+                }
+            }
+            return yield this.postRequest('/userDataStream', {});
+        });
+    }
+    deleteRequest(route, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const now = Date.now();
+            let body = '';
+            params = Object.assign(Object.assign({}, params), { timestamp: now, recvWindow: 5000 * 2 });
+            if (params) {
+                const pMap = [];
+                Object.keys(params).forEach(k => {
+                    pMap.push(`${k}=${encodeURIComponent(params[k])}`);
+                });
+                body = pMap.join('&');
+            }
+            const signature = crypto_js_1.default
+                .HmacSHA256(body, this.credential.secret);
+            params.signature = signature;
+            const header = {
+                'Content-Type': 'application/json',
+                'X-Bitget-APIKEY': this.credential.key,
+            };
+            try {
+                const result = yield this.axios.delete(`${this.privateRestEndpoint}${route}?${body}&signature=${signature}`, {
+                    headers: header,
+                    data: params
+                });
+                return result.data;
+            }
+            catch (error) {
+                console.log(error);
+            }
+        });
+    }
+    getRequest(route, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const now = Date.now();
+            let body = '';
+            params = Object.assign(Object.assign({}, params), { timestamp: now, recvWindow: 5000 * 2 });
+            if (params) {
+                const pMap = [];
+                Object.keys(params).forEach(k => {
+                    pMap.push(`${k}=${params[k]}`);
+                });
+                body = pMap.join('&');
+            }
+            const signature = crypto_js_1.default
+                .HmacSHA256(body, this.credential.secret);
+            params.signature = signature;
+            const header = {
+                'Content-Type': 'application/json',
+                'X-Bitget-APIKEY': this.credential.key,
+            };
+            try {
+                const result = yield this.axios.get(`${this.privateRestEndpoint}${route}?${body}&signature=${signature}`, {
+                    headers: header
+                });
+                return result.data;
+            }
+            catch (error) {
+                console.log(error);
+            }
+        });
+    }
+    postRequest(route, params) {
+        return __awaiter(this, void 0, void 0, function* () {
+            const now = new Date().getTime();
+            let body = undefined;
+            params = Object.assign(Object.assign({}, params), { timestamp: now, recvWindow: 5000 * 2 });
+            if (params) {
+                const pMap = [];
+                Object.keys(params).forEach(k => {
+                    pMap.push(`${k}=${encodeURIComponent(params[k])}`);
+                });
+                body = pMap.join('&');
+            }
+            const signature = crypto_js_1.default
+                .HmacSHA256(body, this.credential.secret);
+            params.signature = signature;
+            const header = {
+                'Content-Type': 'application/json',
+                'X-Bitget-APIKEY': this.credential.key,
+            };
+            try {
+                const result = yield this.axios.post(`${this.privateRestEndpoint}${route}?${body}&signature=${signature}`, {}, {
+                    headers: header
+                });
+                return result.data;
+            }
+            catch (error) {
+                logger.log(`POST Error: ${error.toString()}`);
+            }
+        });
+    }
+    chunkArray(array, chunkSize) {
+        const chunks = [];
+        for (let i = 0; i < array.length; i += chunkSize) {
+            chunks.push(array.slice(i, i + chunkSize));
+        }
+        return chunks;
+    }
+}
+exports.BitgetSpotPrivateConnector = BitgetSpotPrivateConnector;

--- a/Bitget (dziabko)/bitget-spot-private-connector.ts
+++ b/Bitget (dziabko)/bitget-spot-private-connector.ts
@@ -1,0 +1,537 @@
+import {
+    ConnectorConfiguration,
+    ConnectorGroup,
+    PrivateExchangeConnector,
+    Serializable,
+    SklEvent,
+    Credential,
+    OrderState,
+    Side,
+    OrderStatusUpdate,
+    CancelOrdersRequest,
+    OpenOrdersRequest,
+    BalanceRequest,
+    BalanceResponse,
+    BatchOrdersRequest
+} from "../../types";
+
+import { Logger } from "../../util/logging";
+import CryptoJS from 'crypto-js';
+import axios, { AxiosStatic } from 'axios';
+import { WebSocket } from 'ws'
+import { getBitgetSymbol, BitgetInvertedSideMap, BitgetSideMap, BitgetStringSideMap } from "./bitget-spot";
+import { getSklSymbol } from "../../util/config";
+
+export interface BitgetOrderProgress {
+    d: {
+        s: any;
+        S: any;
+        i: any;
+        c: any;
+        p: any;
+        v: any;
+        ap: any;
+        a: any;
+        t: any;
+    }
+    t: string;
+}
+
+export type BitgetOrderType = 'LIMIT' | 'MARKET' | 'LIMIT_MAKER' | 'IMMEDIATE_OR_CANCEL';
+
+const BitgetWSOrderUpdateStateMap: { [key: string]: OrderState } = {
+    '1': 'Placed',
+    '2': 'Filled',
+    '3': 'PartiallyFilled',
+    '4': 'Cancelled',
+    '5': 'CancelledPartiallyFilled',
+}
+
+const BitgetOpenOrdersStateMap: { [key: string]: OrderState } = {
+    'NEW': 'Placed',
+    'PARTIALLY_FILLED': 'PartiallyFilled',
+}
+
+const BitgetOrderTypeMap: { [key: string]: BitgetOrderType } = {
+    'Limit': 'LIMIT',
+    'Market': 'MARKET',
+    'LimitMaker': 'LIMIT_MAKER',
+    'ImmediateOrCancel': 'IMMEDIATE_OR_CANCEL'
+}
+
+const logger = Logger.getInstance('Bitget-spot-private-connector')
+
+export class BitgetSpotPrivateConnector implements PrivateExchangeConnector {
+
+    public connectorId: string;
+
+    public privateWebsocketAddress = 'wss://ws.bitget.com/v2/ws/private';
+
+    public privateRestEndpoint = 'https://api.Bitget.com/api/v3';
+
+    public privateWSFeed: any;
+
+    private pingInterval: any;
+
+    private axios: AxiosStatic;
+
+    private exchangeSymbol: string;
+
+    private sklSymbol: string;
+
+    constructor(
+        private group: ConnectorGroup,
+        private config: ConnectorConfiguration,
+        private credential: Credential
+    ) {
+        const self = this
+        self.exchangeSymbol = getBitgetSymbol(self.group, self.config);
+        self.sklSymbol = getSklSymbol(self.group, self.config);
+
+        self.axios = axios;
+    }
+
+    public async connect(onMessage: (m: Serializable[]) => void, socket = undefined): Promise<any> {
+
+        return new Promise(async (resolve) => {
+
+            const key = await this.safeGetListenKey();
+
+            const url = this.privateWebsocketAddress + `?listenKey=${key.listenKey}`;
+
+            this.privateWSFeed = socket || new WebSocket(url);
+
+            this.privateWSFeed.on('open', () => {
+
+                const message = JSON.stringify({
+                    'method': 'SUBSCRIPTION',
+                    'params': [
+                        'spot@private.deals.v3.api',
+                        'spot@private.orders.v3.api'
+                    ]
+                });
+
+                this.privateWSFeed.send(message);
+
+                this.pingInterval = setInterval(() => {
+
+                    console.log('Pinging Bitget');
+
+                    this.privateWSFeed.send(JSON.stringify({
+                        "method": "PING"
+                    }));
+
+                }, 1000 * 10)
+
+                resolve(true);
+
+            });
+
+            this.privateWSFeed.onmessage = (message: { data: any; }) => {
+
+                const data = JSON.parse(message.data);
+
+                const actionType: SklEvent | null = this.getEventType(data)
+
+                if (actionType) {
+
+                    const serializableMessages: Serializable[] = this.createSklEvent(actionType, data, this.group)
+
+                    onMessage(serializableMessages);
+
+                } else {
+
+                    logger.log(`No handler for message: ${JSON.stringify(data)}`)
+
+                }
+
+            }
+
+            this.privateWSFeed.on('error', function error(err: any) {
+
+                logger.log(`WebSocket error: ${err.toString()}`);
+
+            });
+
+            this.privateWSFeed.on('close', (code, reason) => {
+
+                logger.log(`WebSocket closed: ${code} - ${reason}`);
+
+                setTimeout(() => {
+
+                    clearInterval(this.pingInterval);
+
+                    this.connect(onMessage)
+
+                }, 1000);
+
+            });
+
+            if (this.privateWSFeed.__init !== undefined) {
+
+                this.privateWSFeed.__init();
+
+            }
+
+        });
+
+    }
+
+    public async stop(cancelOrders = true) {
+
+        clearInterval(this.pingInterval);
+
+        const message = JSON.stringify({
+            'op': 'UNSUBSCRIPTION',
+            'params': [
+                'spot@private.deals.v3.api',
+                'spot@private.orders.v3.api'
+            ]
+        });
+
+        this.privateWSFeed.send(message);
+
+        if (cancelOrders === true && this.exchangeSymbol !== undefined) {
+
+            const event = 'CancelOrdersRequest';
+
+            return await this.deleteAllOrders({
+                connectorType: this.config.connectorType,
+                event,
+                symbol: this.exchangeSymbol,
+                timestamp: new Date().getTime(),
+            });
+
+        }
+
+    }
+
+    public async getCurrentActiveOrders(request: OpenOrdersRequest): Promise<OrderStatusUpdate[]> {
+
+        const orders = await this.getRequest('/openOrders', {
+            symbol: this.exchangeSymbol
+        });
+
+        logger.log(`RPC Response: OpenOrdersResponse -> ${JSON.stringify(orders)}`)
+
+        if (orders !== undefined) {
+
+            return orders.map((o) => {
+                return <OrderStatusUpdate>{
+                    event: 'OrderStatusUpdate',
+                    connectorType: 'Bitget',
+                    symbol:  this.sklSymbol,
+                    orderId: o.orderId,
+                    sklOrderId: o.clientOrderId,
+                    state: BitgetOpenOrdersStateMap[o.status],
+                    side: BitgetStringSideMap[o.side],
+                    price: parseFloat(o.price),
+                    size: parseFloat(o.origQty),
+                    notional: parseFloat(o.price) * parseFloat(o.origQty),
+                    filled_price: parseFloat(o.price),
+                    filled_size: parseFloat(o.executedQty),
+                    timestamp: o.time
+                }
+            })
+        }
+
+        return [];
+
+    }
+
+    public async getBalancePercentage(request: BalanceRequest): Promise<BalanceResponse> {
+        const self = this
+        const result = await this.getRequest('/account', {});
+
+        const baseAsset = self.group.name
+        const quoteAsset = self.config.quoteAsset
+        console.log(baseAsset);
+
+        const usdt = result.balances.find(d => d.asset === quoteAsset) || { free: 0, locked: 0 };
+
+        const base = result.balances.find(d => d.asset === baseAsset) || { free: 0, locked: 0 };
+
+        const baseVal = parseFloat(base.free) + parseFloat(base.locked);
+
+        const baseValue = parseFloat(<any>(baseVal * request.lastPrice));
+
+        const usdtValue = parseFloat(usdt.free) + parseFloat(usdt.locked);
+
+        const whole = parseFloat(<any>baseValue) + usdtValue;
+
+        const pairPercentage = (baseValue / whole) * 100;
+
+        return {
+            event: "BalanceRequest",
+            symbol: this.sklSymbol,
+            baseBalance: baseVal,
+            quoteBalance: usdtValue,
+            inventory: pairPercentage,
+            timestamp: new Date().getTime()
+        }
+    }
+
+    public async placeOrders(request: BatchOrdersRequest): Promise<any> {
+        const self = this
+        const orders = request.orders.map(o => {
+            const side = BitgetInvertedSideMap[o.side]
+            const type = BitgetOrderTypeMap[o.type]
+            return {
+                symbol: self.exchangeSymbol,
+                quantity: o.size.toFixed(8),
+                price: o.price.toFixed(8),
+                side,
+                type,
+            };
+        })
+
+        const batches = this.chunkArray(orders, 20);
+
+        const pArray = batches.map(batch => {
+
+            return this.postRequest('/batchOrders', {
+                batchOrders: JSON.stringify(batch)
+            });
+        })
+
+        const [completedBatches] = await Promise.all(pArray)
+        logger.log(`Place order result: ${JSON.stringify(completedBatches)}`)
+        if (completedBatches.find(b => b.code !== undefined)) {
+            return Promise.reject(`At least one order in batch failed: ${JSON.stringify(completedBatches)}`)
+        } else {
+            return completedBatches
+        }
+    }
+
+    public async deleteAllOrders(request: CancelOrdersRequest): Promise<any> {
+        const self = this
+        return await self.deleteRequest('/openOrders', {
+            symbol: self.exchangeSymbol
+        });
+    }
+
+    private getEventType(message: any): SklEvent | null {
+
+        if('code' in message && 'msg' in message) {
+            logger.log(`Subscription response: ${message.code} - ${message.msg}`)
+            return null
+        }else if ('c' in message) {
+            if (message.c.startsWith('spot@private.orders.v3.api')) {
+                return 'OrderStatusUpdate'
+            }
+        }else{
+            return null
+        }
+    }
+
+    private createSklEvent(event: SklEvent, message: any, group: ConnectorGroup): Serializable[] {
+
+        if (event === 'OrderStatusUpdate') {
+
+            return [this.createOrderStatusUpdate(event, message, group)]
+
+        } else {
+
+            return [];
+
+        }
+    }
+
+    private createOrderStatusUpdate(action: SklEvent, order: BitgetOrderProgress, group: ConnectorGroup): OrderStatusUpdate {
+
+        const state: OrderState = BitgetWSOrderUpdateStateMap[order.d.s]
+
+        const side: Side = BitgetSideMap[order.d.S]
+
+        return {
+            symbol: this.sklSymbol,
+            connectorType: 'Bitget',
+            event: action,
+            state,
+            orderId: order.d.i,
+            sklOrderId: order.d.c,
+            side,
+            price: parseFloat(order.d.p),
+            size: order.d.v,
+            notional: parseFloat(order.d.p) * parseFloat(order.d.v),
+            filled_price: parseFloat(order.d.ap),
+            filled_size: parseFloat(order.d.a),
+            timestamp: parseInt(order.t)
+        }
+    }
+
+    private async safeGetListenKey() {
+
+        const keys = await this.getRequest('/userDataStream', {});
+
+        console.log('Roating Keys, found', keys);
+
+        if (keys && keys.listenKey !== undefined) {
+
+            for (const key of keys.listenKey) {
+
+                await this.deleteRequest('/userDataStream', { listenKey: key });
+
+            }
+
+        }
+
+        return await this.postRequest('/userDataStream', {});
+
+    }
+
+    private async deleteRequest(route, params): Promise<any> {
+
+        const now = Date.now()
+
+        let body = '';
+
+        params = { ...params, timestamp: now, recvWindow: 5000 * 2 };
+
+        if (params) {
+
+            const pMap = [];
+
+            Object.keys(params).forEach(k => {
+
+                pMap.push(`${k}=${encodeURIComponent(params[k])}`);
+
+            });
+
+            body = pMap.join('&');
+
+        }
+
+        const signature = CryptoJS
+            .HmacSHA256(body, this.credential.secret);
+
+        params.signature = signature;
+
+        const header = {
+            'Content-Type': 'application/json',
+            'X-Bitget-APIKEY': this.credential.key,
+        }
+
+        try {
+
+            const result = await this.axios.delete(`${this.privateRestEndpoint}${route}?${body}&signature=${signature}`, {
+                headers: header,
+                data: params
+            });
+
+            return result.data;
+
+        } catch (error) {
+
+            console.log(error);
+
+        }
+
+    }
+
+    private async getRequest(route, params): Promise<any> {
+
+        const now = Date.now()
+
+        let body = '';
+
+        params = { ...params, timestamp: now, recvWindow: 5000 * 2 };
+
+        if (params) {
+
+            const pMap = [];
+
+            Object.keys(params).forEach(k => {
+
+                pMap.push(`${k}=${params[k]}`);
+
+            });
+
+            body = pMap.join('&');
+
+        }
+
+        const signature = CryptoJS
+            .HmacSHA256(body, this.credential.secret);
+        params.signature = signature;
+
+        const header = {
+            'Content-Type': 'application/json',
+            'X-Bitget-APIKEY': this.credential.key,
+        }
+
+        try {
+
+            const result = await this.axios.get(`${this.privateRestEndpoint}${route}?${body}&signature=${signature}`, {
+                headers: header
+            });
+
+            return result.data;
+
+        } catch (error) {
+
+            console.log(error);
+
+        }
+
+    }
+
+    private async postRequest(route, params): Promise<any> {
+
+        const now = new Date().getTime();
+
+        let body = undefined;
+
+        params = { ...params, timestamp: now, recvWindow: 5000 * 2 };
+
+        if (params) {
+
+            const pMap = [];
+
+            Object.keys(params).forEach(k => {
+
+                pMap.push(`${k}=${encodeURIComponent(params[k])}`);
+
+            });
+
+            body = pMap.join('&');
+
+        }
+
+        const signature = CryptoJS
+            .HmacSHA256(body, this.credential.secret)
+        params.signature = signature;
+
+        const header = {
+            'Content-Type': 'application/json',
+            'X-Bitget-APIKEY': this.credential.key,
+        }
+
+        try {
+
+            const result = await this.axios.post(`${this.privateRestEndpoint}${route}?${body}&signature=${signature}`, {}, {
+                headers: header
+            });
+
+            return result.data;
+
+        } catch (error) {
+            logger.log(`POST Error: ${error.toString()}`);
+        }
+
+    }
+
+    private chunkArray(array, chunkSize): any {
+
+        const chunks = [];
+
+        for (let i = 0; i < array.length; i += chunkSize) {
+
+            chunks.push(array.slice(i, i + chunkSize));
+
+        }
+
+        return chunks;
+
+    }
+}

--- a/Bitget (dziabko)/bitget-spot-public-connector.js
+++ b/Bitget (dziabko)/bitget-spot-public-connector.js
@@ -1,0 +1,267 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.BitgetSpotPublicConnector = void 0;
+// import { ConnectorConfiguration, ConnectorGroup, PublicExchangeConnector, Serializable, SklEvent, Ticker, TopOfBook, Trade } from "../../types";
+// import { Serializable } from "child_process";
+// import { getSklSymbol } from "../../util/config";
+// import { Logger } from "../../util/logging";
+const bitget_spot_1 = require("./bitget-spot");
+const ws_1 = require("ws");
+// export interface BitgetTradeMessage {
+//     s: string;
+//     d: {
+//         deals: Array<BitgetTrade>
+//     }
+//     t: number;
+// }
+// export interface BitgetTrade { p: string, S: number, v: string, t: number };
+class BitgetSpotPublicConnector {
+    constructor() {
+        // constructor(private group: ConnectorGroup, private config: ConnectorConfiguration) {
+        // const self = this
+        // self.exchangeSymbol = getBitgetSymbol(self.group, self.config);
+        this.publicWebsocketAddress = 'wss://ws.bitget.com/spot/v1/stream';
+        // public publicWebsocketAddress = 'wss://ws.bitget.com/v2/ws/public';
+        this.retryCount = 0;
+        // Define which channels to subscribe to
+        this.channelArguments = {
+            args: [{
+                    instType: "sp",
+                    channel: "trade",
+                    instId: "ETHUSDT",
+                }],
+        };
+        this.sklSymbol = "SKL";
+        // self.sklSymbol = getSklSymbol(self.group, self.config);
+    }
+    connect(onMessage_1) {
+        return __awaiter(this, arguments, void 0, function* (onMessage, socket = undefined) {
+            // public async connect(socket = undefined): Promise<any> {
+            return new Promise((resolve, reject) => __awaiter(this, void 0, void 0, function* () {
+                console.log(`Attempting to connect to Bitget`);
+                const url = this.publicWebsocketAddress;
+                this.publicWSFeed = socket || new ws_1.WebSocket(url);
+                this.publicWSFeed.on('open', () => {
+                    try {
+                        // Hardcoding values for now but this can be obtained via props
+                        setTimeout(() => {
+                            // Hardcoding values for now but this can be obtained via props
+                            this.subscribeToChannels();
+                        }, 1000);
+                        this.retryCount = 0;
+                    }
+                    catch (err) {
+                        console.error(`Error while connecting to WebSocket: ${err}`);
+                    }
+                    // try {
+                    // const message = JSON.stringify({
+                    //     'method': 'SUBSCRIPTION',
+                    //     'params': [
+                    //         `spot@public.deals.v3.api@${this.exchangeSymbol}`,
+                    //         `spot@public.limit.depth.v3.api@${this.exchangeSymbol}@5`,
+                    //         `spot@public.miniTicker.v3.api@${this.exchangeSymbol}@UTC+0`
+                    //     ]
+                    // });
+                    // this.publicWSFeed.send(message);
+                    // this.pingInterval = setInterval(() => {
+                    //     console.log('Pinging Bitget');
+                    //     this.publicWSFeed.send(JSON.stringify({
+                    //         "method": "PING"
+                    //     }));
+                    // }, 1000 * 10)
+                    // resolve(true);
+                    // } catch (err: any) {
+                    //     logger.error(`Error during WebSocket open event: ${err.message}`);
+                    //     reject(err);
+                    // }
+                });
+                this.publicWSFeed.onmessage = (message) => {
+                    try {
+                        console.log(1);
+                        const data = JSON.parse(message.data);
+                        console.log(2);
+                        const actionType = this.getEventType(data);
+                        console.log(3);
+                        this.handleMessage(data, onMessage);
+                        console.log(4);
+                    }
+                    catch (err) {
+                        console.error(`Error processing WebSocket message: ${err}`);
+                    }
+                };
+                this.publicWSFeed.on('error', function error(err) {
+                    console.log(`WebSocket error: ${err.toString()}`);
+                });
+                this.publicWSFeed.on('close', (code, reason) => {
+                    console.log(`WebSocket closed: ${code} - ${reason}`);
+                    setTimeout(() => {
+                        clearInterval(this.pingInterval);
+                        this.connect(onMessage);
+                    }, 1000);
+                });
+                if (this.publicWSFeed.__init !== undefined) {
+                    this.publicWSFeed.__init();
+                }
+            }));
+        });
+    }
+    stop() {
+        return __awaiter(this, void 0, void 0, function* () {
+            clearInterval(this.pingInterval);
+            const message = {
+                op: "unsubscribe",
+                args: this.channelArguments.args,
+            };
+            this.publicWSFeed.send(JSON.stringify(message));
+            this.publicWSFeed.close();
+        });
+    }
+    subscribeToChannels() {
+        const subscriptionMessage = {
+            op: 'subscribe',
+            args: this.channelArguments.args,
+        };
+        this.publicWSFeed.send(JSON.stringify(subscriptionMessage));
+        console.log('Subscribed to channels:', this.channelArguments.args);
+    }
+    handleMessage(data, onMessage) {
+        console.log("HandleMessage1");
+        console.log("DATA: ", data);
+        var message;
+        try {
+            message = JSON.parse(JSON.stringify(data));
+        }
+        catch (error) {
+            console.error("Failed to parse JSON:", error);
+            console.log("DATA: ", data);
+            return;
+        }
+        console.log("HandleMessage2");
+        const eventType = this.getEventType(message);
+        console.log("EVENTTYPE: ", eventType);
+        console.log("HandleMessage3");
+        if (eventType) {
+            const serializableMessages = this.createSerializableEvents(eventType, message);
+            if (serializableMessages.length > 0) {
+                console.log("onMessage(serializableMessages)");
+                console.log(serializableMessages);
+                onMessage(serializableMessages);
+            }
+        }
+        else {
+            // Log unrecognized messages
+        }
+    }
+    createSerializableEvents(eventType, eventData) {
+        switch (eventType) {
+            case 'Trade': {
+                // const trade = ({
+                //     ts: eventData.data[0][0],
+                //     px: eventData.data[0][1],
+                //     sz: eventData.data[0][2],
+                //     side: eventData.data[0][3],
+                // })
+                // const trades = trade as unknown as Types.BitgetTrade
+                //TODO: Iterate over data array
+                const trade = {
+                    instType: eventData.arg.instType,
+                    channel: eventData.arg.channel,
+                    instId: eventData.arg.instId,
+                    timestamp: Number(eventData.data[0][0]),
+                    price: eventData.data[0][1],
+                    size: eventData.data[0][2],
+                    side: eventData.data[0][3]
+                };
+                //  eventData.params.data as unknown as Types.BitgetTrade[]
+                // return trade.map((trade: Types.BitgetTrade) => this.createTrade(trade)).filter((trade) => trade !== null)
+                return [this.createTrade(trade)].filter((e) => e !== null);
+            }
+            case 'Ticker': {
+                const ticker = eventData.params.data;
+                return [this.createTicker(ticker)].filter((e) => e !== null);
+            }
+            default:
+                return [];
+        }
+    }
+    getEventType(message) {
+        if (message.arg.channel === 'trade') {
+            return 'Trade';
+        }
+        else if (message.arg.channel === 'ticker') {
+            return 'Ticker';
+        }
+        else if (message.op === 'subscription') {
+            console.info(`Subscription confirmed: ${JSON.stringify(message)}`);
+            return null;
+        }
+        else if (message.event === 'error') {
+            console.error(`Error message received: ${message.error}`);
+            return null;
+        }
+        return null;
+    }
+    // private createSklEvent(event: SklEvent, message: any, group: ConnectorGroup): Serializable[] {
+    //     if (event === 'TopOfBook') {
+    //         return [this.createTopOfBook(message, group)]
+    //     }
+    //     else if (event === 'Trade') {
+    //         const trades = message.d.deals.sort((a: BitgetTrade, b: BitgetTrade) => b.t - a.t)
+    //         return trades.map((trade: BitgetTrade) => this.createTrade(trade, group))
+    //     } else if (event === 'Ticker') {
+    //         return [this.createTicker(message, group)]
+    //     } else {
+    //         return []
+    //     }
+    // }
+    createTopOfBook(marketDepth, group) {
+        return {
+            symbol: this.sklSymbol,
+            connectorType: 'Bitget',
+            event: 'TopOfBook',
+            timestamp: marketDepth.t,
+            askPrice: parseFloat(marketDepth.d.asks[0].p),
+            askSize: parseFloat(marketDepth.d.asks[0].v),
+            bidPrice: parseFloat(marketDepth.d.bids[0].p),
+            bidSize: parseFloat(marketDepth.d.bids[0].v),
+        };
+    }
+    createTicker(ticker) {
+        return {
+            event: 'Ticker',
+            connectorType: 'Bitget',
+            symbol: ticker.arg.instId,
+            lastPrice: parseFloat(ticker.data[0].last),
+            timestamp: ticker.data[0].ts * 1000,
+        };
+    }
+    createTrade(trade) {
+        console.log("createTrade");
+        console.log(trade);
+        const tradeSide = trade.side;
+        if (tradeSide) {
+            return {
+                event: 'Trade',
+                connectorType: 'Bitget',
+                symbol: trade.instId,
+                price: Number(trade.price),
+                size: Number(trade.size),
+                side: bitget_spot_1.BitgetSideMap[trade.side],
+                timestamp: (new Date(trade.timestamp)).getTime(),
+            };
+        }
+        else {
+            return null;
+        }
+    }
+}
+exports.BitgetSpotPublicConnector = BitgetSpotPublicConnector;

--- a/Bitget (dziabko)/bitget-spot-public-connector.ts
+++ b/Bitget (dziabko)/bitget-spot-public-connector.ts
@@ -1,0 +1,353 @@
+import * as Types from "./types"
+// import { ConnectorConfiguration, ConnectorGroup, PublicExchangeConnector, Serializable, SklEvent, Ticker, TopOfBook, Trade } from "../../types";
+// import { Serializable } from "child_process";
+// import { getSklSymbol } from "../../util/config";
+// import { Logger } from "../../util/logging";
+import { getBitgetSymbol, BitgetSideMap } from "./bitget-spot";
+import { WebSocket } from 'ws'
+
+// const logger = Logger.getInstance('Bitget-spot-public-connector');
+
+export interface BitgetMarketDepth {
+    d: {
+        asks: Array<{ p: string, v: string }>;
+        bids: Array<{ p: string, v: string }>;
+    }
+    s: string;
+    t: number;
+}
+
+// export interface BitgetTradeMessage {
+//     s: string;
+//     d: {
+//         deals: Array<BitgetTrade>
+//     }
+//     t: number;
+// }
+
+// export interface BitgetTrade { p: string, S: number, v: string, t: number };
+
+export class BitgetSpotPublicConnector implements PublicExchangeConnector {
+
+    public publicWebsocketAddress = 'wss://ws.bitget.com/spot/v1/stream';
+    // public publicWebsocketAddress = 'wss://ws.bitget.com/v2/ws/public';
+
+    private retryCount = 0;
+    public publicWSFeed: any;
+
+    private pingInterval: any;
+
+    // private exchangeSymbol: string;
+    private channelArguments: Types.channelRequest;
+    // =  {
+    //     instType: "SP",
+    //     channel: "candle1m",
+    //     instId: "BTC-USDT",
+    //     };
+
+    private sklSymbol: string;
+
+    constructor() {
+    // constructor(private group: ConnectorGroup, private config: ConnectorConfiguration) {
+        // const self = this
+        // self.exchangeSymbol = getBitgetSymbol(self.group, self.config);
+
+        // Define which channels to subscribe to
+        this.channelArguments = {
+            args: [{
+                instType: "sp",
+                channel: "trade",
+                instId: "ETHUSDT",
+            }],
+        };
+        this.sklSymbol = "SKL";
+        // self.sklSymbol = getSklSymbol(self.group, self.config);
+
+    }
+
+    public async connect(onMessage: (m: Types.Serializable[]) => void, socket = undefined): Promise<any> {
+    // public async connect(socket = undefined): Promise<any> {
+
+        return new Promise(async (resolve, reject) => {
+
+            console.log(`Attempting to connect to Bitget`);
+
+            const url = this.publicWebsocketAddress;
+
+            this.publicWSFeed = socket || new WebSocket(url);
+
+            this.publicWSFeed.on('open', () => {
+                try {
+                    // Hardcoding values for now but this can be obtained via props
+                    setTimeout(() => {
+                        // Hardcoding values for now but this can be obtained via props
+                        this.subscribeToChannels()
+                    }, 1000)
+                    this.retryCount = 0;
+                } catch (err) {
+                    console.error(`Error while connecting to WebSocket: ${err}`);
+                }
+                // try {
+
+                // const message = JSON.stringify({
+                //     'method': 'SUBSCRIPTION',
+                //     'params': [
+                //         `spot@public.deals.v3.api@${this.exchangeSymbol}`,
+                //         `spot@public.limit.depth.v3.api@${this.exchangeSymbol}@5`,
+                //         `spot@public.miniTicker.v3.api@${this.exchangeSymbol}@UTC+0`
+                //     ]
+                // });
+
+                // this.publicWSFeed.send(message);
+
+                // this.pingInterval = setInterval(() => {
+
+                //     console.log('Pinging Bitget');
+
+                //     this.publicWSFeed.send(JSON.stringify({
+                //         "method": "PING"
+                //     }));
+
+                // }, 1000 * 10)
+
+                // resolve(true);
+                // } catch (err: any) {
+                //     logger.error(`Error during WebSocket open event: ${err.message}`);
+                //     reject(err);
+                // }
+            }
+            );
+
+            this.publicWSFeed.onmessage = (message: { data: any; }) => {
+
+                try {
+                    console.log(1)
+                    const data = JSON.parse(message.data);
+                    console.log(2)
+                    const actionType: Types.SklEvent | null = this.getEventType(data)
+                    console.log(3)
+                    this.handleMessage(data, onMessage)
+                    console.log(4)
+                } catch (err) {
+                    console.error(`Error processing WebSocket message: ${err}`);
+                }
+
+            }
+
+            this.publicWSFeed.on('error', function error(err: any) {
+                console.log(`WebSocket error: ${err.toString()}`);
+            });
+
+            this.publicWSFeed.on('close', (code: any, reason: any) => {
+
+                console.log(`WebSocket closed: ${code} - ${reason}`);
+
+                setTimeout(() => {
+
+                    clearInterval(this.pingInterval);
+
+                    this.connect(onMessage)
+
+                }, 1000);
+
+            });
+
+            if (this.publicWSFeed.__init !== undefined) {
+
+                this.publicWSFeed.__init();
+
+            }
+
+        });
+
+    }
+
+    public async stop() {
+        clearInterval(this.pingInterval);
+
+        const message = {
+            op: "unsubscribe",
+            args: this.channelArguments.args,
+        };
+
+        this.publicWSFeed.send(JSON.stringify(message));
+        this.publicWSFeed.close();
+    }
+
+
+    private subscribeToChannels(): void {
+
+        const subscriptionMessage = {
+            op: 'subscribe',
+            args: this.channelArguments.args,
+        };
+
+        this.publicWSFeed.send(JSON.stringify(subscriptionMessage));
+        console.log('Subscribed to channels:', this.channelArguments.args);
+    }
+
+    private handleMessage(data: string, onMessage: (messages: Types.Serializable[]) => void): void {
+        console.log("HandleMessage1");
+        console.log("DATA: ", data);
+        var message;
+        try {
+            message = JSON.parse(JSON.stringify(data));
+        } catch (error) {
+            console.error("Failed to parse JSON:", error);
+            console.log("DATA: ", data);
+            return;
+        }
+        console.log("HandleMessage2");
+        const eventType = this.getEventType(message);
+        console.log("EVENTTYPE: ", eventType);
+        console.log("HandleMessage3");
+    
+        if (eventType) {
+            const serializableMessages = this.createSerializableEvents(eventType, message);
+            if (serializableMessages.length > 0) {
+                console.log("onMessage(serializableMessages)");
+                console.log(serializableMessages);
+                onMessage(serializableMessages);
+            }
+        } else {
+            // Log unrecognized messages
+        }
+    }
+
+    private createSerializableEvents(eventType: Types.SklEvent, eventData: Types.BitgetEventData): Types.Serializable[] {
+        switch (eventType) {
+            case 'Trade': {
+                // const trade = ({
+                //     ts: eventData.data[0][0],
+                //     px: eventData.data[0][1],
+                //     sz: eventData.data[0][2],
+                //     side: eventData.data[0][3],
+                // })
+                // const trades = trade as unknown as Types.BitgetTrade
+
+                //TODO: Iterate over data array
+                const trade: Types.BitgetTrade = {
+                    instType: eventData.arg.instType,
+                    channel: eventData.arg.channel,
+                    instId: eventData.arg.instId,
+                    timestamp: Number(eventData.data[0][0]),
+                    price: eventData.data[0][1],
+                    size: eventData.data[0][2],
+                    side: eventData.data[0][3]
+                }
+                //  eventData.params.data as unknown as Types.BitgetTrade[]
+                // return trade.map((trade: Types.BitgetTrade) => this.createTrade(trade)).filter((trade) => trade !== null)
+                return [this.createTrade(trade)].filter((e) => e !== null);
+            }
+            case 'Ticker': {
+                const ticker = eventData.params.data as unknown as Types.BitgetTicker
+                return [this.createTicker(ticker)].filter((e) => e !== null);
+            }
+            default:
+                return [];
+        }
+    }
+
+    private getEventType(message: any): Types.SklEvent | null {
+        if (message.arg.channel === 'trade') {
+            return 'Trade';
+        }  else if (message.arg.channel === 'ticker') {
+            return 'Ticker';
+        } else if (message.op === 'subscription') {
+            console.info(`Subscription confirmed: ${JSON.stringify(message)}`);
+            return null;
+        } else if (message.event === 'error') {
+            console.error(`Error message received: ${message.error}`);
+            return null;
+        }
+        return null;
+    }
+
+    // private createSklEvent(event: SklEvent, message: any, group: ConnectorGroup): Serializable[] {
+
+    //     if (event === 'TopOfBook') {
+
+    //         return [this.createTopOfBook(message, group)]
+
+    //     }
+    //     else if (event === 'Trade') {
+
+    //         const trades = message.d.deals.sort((a: BitgetTrade, b: BitgetTrade) => b.t - a.t)
+
+    //         return trades.map((trade: BitgetTrade) => this.createTrade(trade, group))
+
+    //     } else if (event === 'Ticker') {
+
+    //         return [this.createTicker(message, group)]
+
+    //     } else {
+
+    //         return []
+
+    //     }
+    // }
+
+    private createTopOfBook(marketDepth: BitgetMarketDepth, group: ConnectorGroup): TopOfBook {
+        return {
+            symbol: this.sklSymbol,
+            connectorType: 'Bitget',
+            event: 'TopOfBook',
+            timestamp: marketDepth.t,
+            askPrice: parseFloat(marketDepth.d.asks[0].p),
+            askSize: parseFloat(marketDepth.d.asks[0].v),
+            bidPrice: parseFloat(marketDepth.d.bids[0].p),
+            bidSize: parseFloat(marketDepth.d.bids[0].v),
+        };
+    }
+
+    private createTicker(ticker: Types.BitgetTicker): Ticker {
+        return {
+            event: 'Ticker',
+            connectorType: 'Bitget',
+            symbol: ticker.arg.instId,
+            lastPrice: parseFloat(ticker.data[0].last),
+            timestamp: ticker.data[0].ts * 1000,
+        };
+    }
+
+    private createTrade(trade: Types.BitgetTrade): Types.SklTrade | null {
+        console.log("createTrade");
+        console.log(trade);
+        const tradeSide: string | undefined = trade.side
+        if (tradeSide) {
+            return {
+                event: 'Trade',
+                connectorType: 'Bitget',
+                symbol: trade.instId,
+                price: Number(trade.price),
+                size: Number(trade.size),
+                side: BitgetSideMap[trade.side],
+                timestamp: (new Date(trade.timestamp)).getTime(),
+            }
+        } else {
+            return null
+        }
+    }
+
+    // private createTrade(trade: BitgetTrade, group: ConnectorGroup): Trade | null {
+
+    //     const tradeSide: number | undefined = trade.S;
+
+    //     if (tradeSide) {
+    //         return {
+    //             symbol: this.sklSymbol,
+    //             connectorType: 'Bitget',
+    //             event: 'Trade',
+    //             price: parseFloat(trade.p),
+    //             size: parseFloat(trade.v),
+    //             side: BitgetSideMap[tradeSide],
+    //             timestamp: trade.t * 1000,
+    //         }
+    //     } else {
+
+    //         return null;
+
+    //     }
+    // }
+
+}

--- a/Bitget (dziabko)/bitget-spot.js
+++ b/Bitget (dziabko)/bitget-spot.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getBitgetSymbol = exports.BitgetInvertedSideMap = exports.BitgetStringSideMap = exports.BitgetSideMap = void 0;
+exports.BitgetSideMap = {
+    'buy': 'Buy',
+    'sell': 'Sell'
+};
+exports.BitgetStringSideMap = {
+    'BUY': 'Buy',
+    'SELL': 'Sell'
+};
+exports.BitgetInvertedSideMap = {
+    'Buy': 'BUY',
+    'Sell': 'SELL'
+};
+const getBitgetSymbol = (symbolGroup, connectorConfig) => {
+    return `${symbolGroup.name}${connectorConfig.quoteAsset}`;
+};
+exports.getBitgetSymbol = getBitgetSymbol;

--- a/Bitget (dziabko)/bitget-spot.spec.js
+++ b/Bitget (dziabko)/bitget-spot.spec.js
@@ -1,0 +1,470 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const Bitget_spot_public_connector_1 = require("./Bitget-spot-public-connector");
+const Bitget_spot_private_connector_1 = require("./Bitget-spot-private-connector");
+global.WebSocket = require('ws');
+const axios_1 = __importDefault(require("axios"));
+const config_1 = require("../../util/config");
+jest.mock('axios');
+describe('Bitget: Public connector', () => {
+    let connector;
+    const mockGroup = { name: 'mock-group', quoteAsset: 'usdt' };
+    const mockConfig = { symbol: 'mock-symbol', quoteAsset: 'usdt' };
+    beforeEach(() => {
+        connector = new Bitget_spot_public_connector_1.BitgetSpotPublicConnector(mockGroup, mockConfig);
+    });
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+    it('Can handle TopOfBook command', () => __awaiter(void 0, void 0, void 0, function* () {
+        const handlerMap = {};
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+        yield connector.connect((msg) => {
+            const expected = {
+                symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'TopOfBook',
+                timestamp: 1661932660144,
+                askPrice: 20290.89,
+                askSize: 0.67,
+                bidPrice: 20290.89,
+                bidSize: 0.67
+            };
+            expect(msg[0]).toStrictEqual(expected);
+        }, imp);
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@public.limit.depth.v3.api@BTCUSDT@5",
+                "d": {
+                    "asks": [{
+                            "p": "20290.89",
+                            "v": "0.670000"
+                        }],
+                    "bids": [{
+                            "p": "20290.89",
+                            "v": "0.670000"
+                        }],
+                    "e": "spot@public.limit.depth.v3.api",
+                    "r": "3407459756"
+                },
+                "s": "BTCUSDT",
+                "t": 1661932660144
+            })
+        };
+        imp.onmessage(depthMessage);
+    }));
+    it('Can handle Ticker command', () => __awaiter(void 0, void 0, void 0, function* () {
+        const handlerMap = {};
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+        yield connector.connect((msg) => {
+            const expected = {
+                symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'Ticker',
+                lastPrice: 36474.74,
+                timestamp: 1699502456051000
+            };
+            expect(msg[0]).toStrictEqual(expected);
+        }, imp);
+        const depthMessage = {
+            data: JSON.stringify({
+                "d": {
+                    "s": "BTCUSDT",
+                    "p": "36474.74",
+                    "r": "0.0354",
+                    "tr": "0.0354",
+                    "h": "36549.72",
+                    "l": "35101.68",
+                    "v": "375173478.65",
+                    "q": "10557.72895",
+                    "lastRT": "-1",
+                    "MT": "0",
+                    "NV": "--",
+                    "t": "1699502456050"
+                },
+                "c": "spot@public.miniTicker.v3.api@BTCUSDT@UTC+8",
+                "t": 1699502456051,
+                "s": "BTCUSDT"
+            })
+        };
+        imp.onmessage(depthMessage);
+    }));
+    it('Can handle Trade (Sell) command', () => __awaiter(void 0, void 0, void 0, function* () {
+        const handlerMap = {};
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+        yield connector.connect((msg) => {
+            const expected = {
+                symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'Trade',
+                price: 20233.84,
+                size: 0.001028,
+                side: 'Sell',
+                timestamp: 1661927587825000
+            };
+            expect(msg[0]).toStrictEqual(expected);
+        }, imp);
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@public.deals.v3.api@BTCUSDT",
+                "d": {
+                    "deals": [{
+                            "S": 2,
+                            "p": "20233.84",
+                            "t": 1661927587825,
+                            "v": "0.001028"
+                        }],
+                    "e": "spot@public.deals.v3.api"
+                },
+                "t": 1661927587836
+            })
+        };
+        imp.onmessage(depthMessage);
+    }));
+    it('Can handle Trade (Buy) command', () => __awaiter(void 0, void 0, void 0, function* () {
+        const handlerMap = {};
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+        yield connector.connect((msg) => {
+            const expected = {
+                symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'Trade',
+                price: 20233.84,
+                size: 0.001028,
+                side: 'Buy',
+                timestamp: 1661927587825000
+            };
+            expect(msg[0]).toStrictEqual(expected);
+        }, imp);
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@public.deals.v3.api@BTCUSDT",
+                "d": {
+                    "deals": [{
+                            "S": 1,
+                            "p": "20233.84",
+                            "t": 1661927587825,
+                            "v": "0.001028"
+                        }],
+                    "e": "spot@public.deals.v3.api"
+                },
+                "t": 1661927587836
+            })
+        };
+        imp.onmessage(depthMessage);
+    }));
+});
+describe('Bitget: Private connector', () => {
+    let connector;
+    const mockGroup = { name: 'mock-group', quoteAsset: 'usdt' };
+    const mockConfig = { symbol: 'mock-symbol', quoteAsset: 'usdt' };
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+    it('Can Connect with handshake command', () => __awaiter(void 0, void 0, void 0, function* () {
+        connector = new Bitget_spot_private_connector_1.BitgetSpotPrivateConnector(mockGroup, mockConfig, {
+            key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+            secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+        });
+        const handlerMap = {};
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+        const ax = axios_1.default;
+        ax.get.mockResolvedValueOnce({
+            data: {
+                listenKey: ['test']
+            }
+        });
+        ax.delete.mockResolvedValueOnce({
+            data: 'ok'
+        });
+        ax.post.mockResolvedValueOnce({
+            data: {
+                listenKey: 'test'
+            }
+        });
+        yield connector.connect((msg) => {
+            expect(true).toStrictEqual(true);
+        }, imp);
+    }));
+    it('Can handle OrderStatusUpdate command', () => __awaiter(void 0, void 0, void 0, function* () {
+        connector = new Bitget_spot_private_connector_1.BitgetSpotPrivateConnector(mockGroup, mockConfig, {
+            key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+            secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+        });
+        const handlerMap = {};
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+        const ax = axios_1.default;
+        ax.get.mockResolvedValueOnce({
+            data: {
+                listenKey: ['test']
+            }
+        });
+        ax.delete.mockResolvedValueOnce({
+            data: 'ok'
+        });
+        ax.post.mockResolvedValueOnce({
+            data: {
+                listenKey: 'test'
+            }
+        });
+        yield connector.connect((msg) => {
+            const expected = {
+                symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'OrderStatusUpdate',
+                state: 'Placed',
+                orderId: 'e03a5c7441e44ed899466a7140b71391',
+                sklOrderId: 'test123',
+                side: 'Buy',
+                price: 0.8,
+                size: 10,
+                notional: 8,
+                filled_price: 0,
+                filled_size: 8,
+                timestamp: 1661938138193
+            };
+            expect(msg[0]).toStrictEqual(expected);
+        }, imp);
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@private.orders.v3.api",
+                "d": {
+                    "A": 8.0,
+                    "O": 1661938138000,
+                    "S": 1,
+                    "V": 10,
+                    "a": 8,
+                    "c": "test123",
+                    "i": "e03a5c7441e44ed899466a7140b71391",
+                    "m": 0,
+                    "o": 1,
+                    "p": 0.8,
+                    "s": 1,
+                    "v": 10,
+                    "ap": 0,
+                    "cv": 0,
+                    "ca": 0
+                },
+                "s": "MXUSDT",
+                "t": 1661938138193
+            })
+        };
+        imp.onmessage(depthMessage);
+    }));
+    it.skip('Can handle getCurrentActiveOrders action', () => __awaiter(void 0, void 0, void 0, function* () {
+        connector = new Bitget_spot_private_connector_1.BitgetSpotPrivateConnector(mockGroup, mockConfig, {
+            key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+            secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+        });
+        const ax = axios_1.default;
+        ax.get.mockResolvedValueOnce({
+            data: [
+                {
+                    "symbol": "LTCBTC",
+                    "orderId": 1,
+                    "orderListId": -1,
+                    "clientOrderId": "myOrder1",
+                    "price": "0.1",
+                    "origQty": "1.0",
+                    "executedQty": "0.0",
+                    "cummulativeQuoteQty": "0.0",
+                    "status": "NEW",
+                    "timeInForce": "GTC",
+                    "type": "LIMIT",
+                    "side": "BUY",
+                    "stopPrice": "0.0",
+                    "icebergQty": "0.0",
+                    "time": 1499827319559,
+                    "updateTime": 1499827319559,
+                    "isWorking": true,
+                    "origQuoteOrderQty": "0.000000"
+                }
+            ]
+        });
+        const result = yield connector.getCurrentActiveOrders({});
+        const expected = [
+            {
+                event: 'OrderStatusUpdate',
+                connectorType: 'Bitget',
+                symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                orderId: 1,
+                sklOrderId: 'myOrder1',
+                state: 'Placed',
+                side: "Buy",
+                price: 0.1,
+                size: 0,
+                notional: 0.1,
+                filled_price: 0.1,
+                filled_size: 0,
+                timestamp: 1499827319559
+            }
+        ];
+        expect(result).toStrictEqual(expected);
+    }));
+    it.skip('Can handle getBalancePercentage action', () => __awaiter(void 0, void 0, void 0, function* () {
+        connector = new Bitget_spot_private_connector_1.BitgetSpotPrivateConnector(mockGroup, mockConfig, {
+            key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+            secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+        });
+        const ax = axios_1.default;
+        ax.get.mockResolvedValueOnce({
+            data: {
+                "makerCommission": 20,
+                "takerCommission": 20,
+                "buyerCommission": 0,
+                "sellerCommission": 0,
+                "canTrade": true,
+                "canWithdraw": true,
+                "canDeposit": true,
+                "updateTime": null,
+                "accountType": "SPOT",
+                "balances": [{
+                        "asset": "USDT",
+                        "free": "500",
+                        "locked": "33"
+                    }, {
+                        "asset": "mock-group",
+                        "free": "1000",
+                        "locked": "33"
+                    }],
+                "permissions": ["SPOT"]
+            }
+        });
+        const result = yield connector.getBalancePercentage({
+            lastPrice: 1
+        });
+        const expected = {
+            event: 'BalanceRequest',
+            symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+            baseBalance: 1033,
+            quoteBalance: 533,
+            inventory: 65.96424010217113,
+            timestamp: 1701171036857
+        };
+        expect(result.event).toStrictEqual(expected.event);
+        expect(result.symbol).toStrictEqual(expected.symbol);
+        expect(result.baseBalance).toStrictEqual(expected.baseBalance);
+        expect(result.quoteBalance).toStrictEqual(expected.quoteBalance);
+        expect(result.inventory).toStrictEqual(expected.inventory);
+    }));
+    it.skip('Can handle placeOrders(buy) action', () => __awaiter(void 0, void 0, void 0, function* () {
+        connector = new Bitget_spot_private_connector_1.BitgetSpotPrivateConnector(mockGroup, mockConfig, {
+            key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+            secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+        });
+        const ax = axios_1.default;
+        const request = {
+            event: 'BatchOrdersRequest',
+            timestamp: new Date().getTime(),
+            orders: [
+                {
+                    connectorType: 'Bitget',
+                    symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                    size: 10,
+                    price: 10,
+                    side: 'Buy',
+                    type: 'Limit',
+                }
+            ]
+        };
+        yield connector.placeOrders(request);
+        const expected = `[{"symbol":"mock-groupusdt","size":"10.00000000","price":"10.00000000","side":"BUY","type":"LIMIT"}]`;
+        expect(ax.post).toHaveBeenLastCalledWith(expect.stringContaining(encodeURIComponent(expected)), {}, { "headers": { "Content-Type": "application/json", "X-Bitget-APIKEY": "9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5" } });
+    }));
+    it.skip('Can handle placeOrders(sell) action', () => __awaiter(void 0, void 0, void 0, function* () {
+        connector = new Bitget_spot_private_connector_1.BitgetSpotPrivateConnector(mockGroup, mockConfig, {
+            key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+            secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+        });
+        const ax = axios_1.default;
+        const request = {
+            event: 'BatchOrdersRequest',
+            timestamp: new Date().getTime(),
+            orders: [
+                {
+                    connectorType: 'Bitget',
+                    symbol: (0, config_1.getSklSymbol)(mockGroup, mockConfig),
+                    size: 10,
+                    price: 10,
+                    side: 'Sell',
+                    type: 'Limit',
+                }
+            ]
+        };
+        yield connector.placeOrders(request);
+        const expected = `[{"symbol":"mock-groupusdt","size":"10.00000000","price":"10.00000000","side":"SELL","type":"LIMIT"}]`;
+        expect(ax.post).toHaveBeenLastCalledWith(expect.stringContaining(encodeURIComponent(expected)), {}, { "headers": { "Content-Type": "application/json", "X-Bitget-APIKEY": "9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5" } });
+    }));
+});

--- a/Bitget (dziabko)/bitget-spot.spec.ts
+++ b/Bitget (dziabko)/bitget-spot.spec.ts
@@ -1,8 +1,8 @@
 
 import { BatchOrdersRequest, OrderStatusUpdate, Ticker, TopOfBook, Trade } from '../../types';
 
-import { BitgetSpotPublicConnector } from './Bitget-spot-public-connector';
-import { BitgetSpotPrivateConnector } from './Bitget-spot-private-connector';
+import { BitgetFuturesPublicConnector } from './bitget-futures-public-connector';
+import { BitgetFuturesPrivateConnector } from './bitget-futures-private-connector';
 
 global.WebSocket = require('ws');
 import axios from 'axios';
@@ -20,7 +20,7 @@ describe('Bitget: Public connector', () => {
     const mockConfig: any = { symbol: 'mock-symbol', quoteAsset: 'usdt' };
 
     beforeEach(() => {
-        connector = new BitgetSpotPublicConnector(mockGroup, mockConfig);
+        connector = new BitgetFuturesPublicConnector(mockGroup, mockConfig);
     });
 
     afterEach(() => {
@@ -261,7 +261,7 @@ describe('Bitget: Private connector', () => {
 
     it('Can Connect with handshake command', async () => {
 
-        connector = new BitgetSpotPrivateConnector(
+        connector = new BitgetFuturesPrivateConnector(
             mockGroup,
             mockConfig,
             <any>{
@@ -311,7 +311,7 @@ describe('Bitget: Private connector', () => {
 
     it('Can handle OrderStatusUpdate command', async () => {
 
-        connector = new BitgetSpotPrivateConnector(
+        connector = new BitgetFuturesPrivateConnector(
             mockGroup,
             mockConfig,
             <any>{
@@ -405,7 +405,7 @@ describe('Bitget: Private connector', () => {
 
     it.skip('Can handle getCurrentActiveOrders action', async () => {
 
-        connector = new BitgetSpotPrivateConnector(
+        connector = new BitgetFuturesPrivateConnector(
             mockGroup,
             mockConfig,
             <any>{
@@ -467,7 +467,7 @@ describe('Bitget: Private connector', () => {
 
     it.skip('Can handle getBalancePercentage action', async () => {
 
-        connector = new BitgetSpotPrivateConnector(
+        connector = new BitgetFuturesPrivateConnector(
             mockGroup,
             mockConfig,
             <any>{
@@ -524,7 +524,7 @@ describe('Bitget: Private connector', () => {
 
     it.skip('Can handle placeOrders(buy) action', async () => {
 
-        connector = new BitgetSpotPrivateConnector(
+        connector = new BitgetFuturesPrivateConnector(
             mockGroup,
             mockConfig,
             <any>{
@@ -563,7 +563,7 @@ describe('Bitget: Private connector', () => {
 
     it.skip('Can handle placeOrders(sell) action', async () => {
 
-        connector = new BitgetSpotPrivateConnector(
+        connector = new BitgetFuturesPrivateConnector(
             mockGroup,
             mockConfig,
             <any>{

--- a/Bitget (dziabko)/bitget-spot.spec.ts
+++ b/Bitget (dziabko)/bitget-spot.spec.ts
@@ -1,0 +1,602 @@
+
+import { BatchOrdersRequest, OrderStatusUpdate, Ticker, TopOfBook, Trade } from '../../types';
+
+import { BitgetSpotPublicConnector } from './Bitget-spot-public-connector';
+import { BitgetSpotPrivateConnector } from './Bitget-spot-private-connector';
+
+global.WebSocket = require('ws');
+import axios from 'axios';
+import { getSklSymbol } from '../../util/config';
+
+jest.mock('axios');
+
+
+describe('Bitget: Public connector', () => {
+
+    let connector;
+
+    const mockGroup: any = { name: 'mock-group', quoteAsset: 'usdt' };
+
+    const mockConfig: any = { symbol: 'mock-symbol', quoteAsset: 'usdt' };
+
+    beforeEach(() => {
+        connector = new BitgetSpotPublicConnector(mockGroup, mockConfig);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+
+    it('Can handle TopOfBook command', async () => {
+
+        const handlerMap = {}
+
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+
+        await connector.connect((msg) => {
+
+            const expected: TopOfBook = {
+                symbol: getSklSymbol(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'TopOfBook',
+                timestamp: 1661932660144,
+                askPrice: 20290.89,
+                askSize: 0.67,
+                bidPrice: 20290.89,
+                bidSize: 0.67
+            };
+
+            expect(msg[0]).toStrictEqual(expected);
+
+        }, imp)
+
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@public.limit.depth.v3.api@BTCUSDT@5",
+                "d": {
+                    "asks": [{
+                        "p": "20290.89",
+                        "v": "0.670000"
+                    }],
+                    "bids": [{
+                        "p": "20290.89",
+                        "v": "0.670000"
+                    }],
+                    "e": "spot@public.limit.depth.v3.api",
+                    "r": "3407459756"
+                },
+                "s": "BTCUSDT",
+                "t": 1661932660144
+            })
+        };
+
+        imp.onmessage(depthMessage);
+
+    });
+
+    it('Can handle Ticker command', async () => {
+
+        const handlerMap = {}
+
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+
+        await connector.connect((msg) => {
+
+            const expected: Ticker = {
+                symbol: getSklSymbol(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'Ticker',
+                lastPrice: 36474.74,
+                timestamp: 1699502456051000
+            };
+
+            expect(msg[0]).toStrictEqual(expected);
+
+        }, imp)
+
+        const depthMessage = {
+            data: JSON.stringify({
+                "d": {
+                    "s": "BTCUSDT",
+                    "p": "36474.74",
+                    "r": "0.0354",
+                    "tr": "0.0354",
+                    "h": "36549.72",
+                    "l": "35101.68",
+                    "v": "375173478.65",
+                    "q": "10557.72895",
+                    "lastRT": "-1",
+                    "MT": "0",
+                    "NV": "--",
+                    "t": "1699502456050"
+                },
+                "c": "spot@public.miniTicker.v3.api@BTCUSDT@UTC+8",
+                "t": 1699502456051,
+                "s": "BTCUSDT"
+            })
+        };
+
+        imp.onmessage(depthMessage);
+
+    });
+
+    it('Can handle Trade (Sell) command', async () => {
+
+        const handlerMap = {}
+
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+
+        await connector.connect((msg) => {
+
+            const expected: Trade = {
+                symbol: getSklSymbol(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'Trade',
+                price: 20233.84,
+                size: 0.001028,
+                side: 'Sell',
+                timestamp: 1661927587825000
+            };
+
+            expect(msg[0]).toStrictEqual(expected);
+
+        }, imp)
+
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@public.deals.v3.api@BTCUSDT",
+                "d": {
+                    "deals": [{
+                        "S": 2,
+                        "p": "20233.84",
+                        "t": 1661927587825,
+                        "v": "0.001028"
+                    }],
+                    "e": "spot@public.deals.v3.api"
+                },
+                "t": 1661927587836
+            })
+        };
+
+        imp.onmessage(depthMessage);
+
+    });
+
+    it('Can handle Trade (Buy) command', async () => {
+
+        const handlerMap = {}
+
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+
+        await connector.connect((msg) => {
+
+            const expected: Trade = {
+                symbol: getSklSymbol(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'Trade',
+                price: 20233.84,
+                size: 0.001028,
+                side: 'Buy',
+                timestamp: 1661927587825000
+            };
+
+            expect(msg[0]).toStrictEqual(expected);
+
+        }, imp)
+
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@public.deals.v3.api@BTCUSDT",
+                "d": {
+                    "deals": [{
+                        "S": 1,
+                        "p": "20233.84",
+                        "t": 1661927587825,
+                        "v": "0.001028"
+                    }],
+                    "e": "spot@public.deals.v3.api"
+                },
+                "t": 1661927587836
+            })
+        };
+
+        imp.onmessage(depthMessage);
+
+    });
+
+});
+
+describe('Bitget: Private connector', () => {
+
+    let connector;
+
+    const mockGroup: any = { name: 'mock-group', quoteAsset: 'usdt' };
+
+    const mockConfig: any = { symbol: 'mock-symbol', quoteAsset: 'usdt' };
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('Can Connect with handshake command', async () => {
+
+        connector = new BitgetSpotPrivateConnector(
+            mockGroup,
+            mockConfig,
+            <any>{
+                key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+                secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+            },
+        );
+
+        const handlerMap = {}
+
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+
+        const ax: any = axios;
+
+        ax.get.mockResolvedValueOnce({
+            data: {
+                listenKey: ['test']
+            }
+        });
+
+        ax.delete.mockResolvedValueOnce({
+            data: 'ok'
+        });
+
+        ax.post.mockResolvedValueOnce({
+            data: {
+                listenKey: 'test'
+            }
+        });
+
+        await connector.connect((msg) => {
+            expect(true).toStrictEqual(true);
+
+        }, imp)
+
+    });
+
+    it('Can handle OrderStatusUpdate command', async () => {
+
+        connector = new BitgetSpotPrivateConnector(
+            mockGroup,
+            mockConfig,
+            <any>{
+                key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+                secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+            },
+        );
+
+        const handlerMap = {}
+
+        const imp = {
+            on: (command, handler) => {
+                handlerMap[command] = handler;
+            },
+            onmessage: jest.fn(),
+            onerror: jest.fn(),
+            send: jest.fn(),
+            __init: () => {
+                handlerMap['open']();
+            }
+        };
+
+        const ax: any = axios;
+
+        ax.get.mockResolvedValueOnce({
+            data: {
+                listenKey: ['test']
+            }
+        });
+
+        ax.delete.mockResolvedValueOnce({
+            data: 'ok'
+        });
+
+        ax.post.mockResolvedValueOnce({
+            data: {
+                listenKey: 'test'
+            }
+        });
+
+        await connector.connect((msg) => {
+
+            const expected: OrderStatusUpdate = {
+                symbol: getSklSymbol(mockGroup, mockConfig),
+                connectorType: 'Bitget',
+                event: 'OrderStatusUpdate',
+                state: 'Placed',
+                orderId: 'e03a5c7441e44ed899466a7140b71391',
+                sklOrderId: 'test123',
+                side: 'Buy',
+                price: 0.8,
+                size: 10,
+                notional: 8,
+                filled_price: 0,
+                filled_size: 8,
+                timestamp: 1661938138193
+            };
+
+            expect(msg[0]).toStrictEqual(expected);
+
+        }, imp)
+
+        const depthMessage = {
+            data: JSON.stringify({
+                "c": "spot@private.orders.v3.api",
+                "d": {
+                    "A": 8.0,
+                    "O": 1661938138000,
+                    "S": 1,
+                    "V": 10,
+                    "a": 8,
+                    "c": "test123",
+                    "i": "e03a5c7441e44ed899466a7140b71391",
+                    "m": 0,
+                    "o": 1,
+                    "p": 0.8,
+                    "s": 1,
+                    "v": 10,
+                    "ap": 0,
+                    "cv": 0,
+                    "ca": 0
+                },
+                "s": "MXUSDT",
+                "t": 1661938138193
+            })
+        };
+
+        imp.onmessage(depthMessage);
+
+    });
+
+    it.skip('Can handle getCurrentActiveOrders action', async () => {
+
+        connector = new BitgetSpotPrivateConnector(
+            mockGroup,
+            mockConfig,
+            <any>{
+                key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+                secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+            },
+        );
+
+        const ax: any = axios;
+
+        ax.get.mockResolvedValueOnce({
+            data: [
+                {
+                    "symbol": "LTCBTC",
+                    "orderId": 1,
+                    "orderListId": -1,
+                    "clientOrderId": "myOrder1",
+                    "price": "0.1",
+                    "origQty": "1.0",
+                    "executedQty": "0.0",
+                    "cummulativeQuoteQty": "0.0",
+                    "status": "NEW",
+                    "timeInForce": "GTC",
+                    "type": "LIMIT",
+                    "side": "BUY",
+                    "stopPrice": "0.0",
+                    "icebergQty": "0.0",
+                    "time": 1499827319559,
+                    "updateTime": 1499827319559,
+                    "isWorking": true,
+                    "origQuoteOrderQty": "0.000000"
+                }
+            ]
+        });
+
+        const result = await connector.getCurrentActiveOrders({});
+
+        const expected = [
+            {
+                event: 'OrderStatusUpdate',
+                connectorType: 'Bitget',
+                symbol: getSklSymbol(mockGroup, mockConfig),
+                orderId: 1,
+                sklOrderId: 'myOrder1',
+                state: 'Placed',
+                side: "Buy",
+                price: 0.1,
+                size: 0,
+                notional: 0.1,
+                filled_price: 0.1,
+                filled_size: 0,
+                timestamp: 1499827319559
+            }
+        ];
+
+        expect(result).toStrictEqual(expected);
+
+    });
+
+    it.skip('Can handle getBalancePercentage action', async () => {
+
+        connector = new BitgetSpotPrivateConnector(
+            mockGroup,
+            mockConfig,
+            <any>{
+                key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+                secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+            },
+        );
+
+        const ax: any = axios;
+
+        ax.get.mockResolvedValueOnce({
+            data: {
+                "makerCommission": 20,
+                "takerCommission": 20,
+                "buyerCommission": 0,
+                "sellerCommission": 0,
+                "canTrade": true,
+                "canWithdraw": true,
+                "canDeposit": true,
+                "updateTime": null,
+                "accountType": "SPOT",
+                "balances": [{
+                    "asset": "USDT",
+                    "free": "500",
+                    "locked": "33"
+                }, {
+                    "asset": "mock-group",
+                    "free": "1000",
+                    "locked": "33"
+                }],
+                "permissions": ["SPOT"]
+            }
+        });
+
+        const result = await connector.getBalancePercentage({
+            lastPrice: 1
+        });
+
+        const expected = {
+            event: 'BalanceRequest',
+            symbol: getSklSymbol(mockGroup, mockConfig),
+            baseBalance: 1033,
+            quoteBalance: 533,
+            inventory: 65.96424010217113,
+            timestamp: 1701171036857
+        };
+
+        expect(result.event).toStrictEqual(expected.event);
+        expect(result.symbol).toStrictEqual(expected.symbol);
+        expect(result.baseBalance).toStrictEqual(expected.baseBalance);
+        expect(result.quoteBalance).toStrictEqual(expected.quoteBalance);
+        expect(result.inventory).toStrictEqual(expected.inventory);
+    });
+
+    it.skip('Can handle placeOrders(buy) action', async () => {
+
+        connector = new BitgetSpotPrivateConnector(
+            mockGroup,
+            mockConfig,
+            <any>{
+                key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+                secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+            },
+        );
+
+        const ax: any = axios;
+
+        const request: BatchOrdersRequest = {
+            event: 'BatchOrdersRequest',
+            timestamp: new Date().getTime(),
+            orders: [
+                {
+                    connectorType: 'Bitget',
+                    symbol: getSklSymbol(mockGroup, mockConfig),
+                    size: 10,
+                    price: 10,
+                    side: 'Buy',
+                    type: 'Limit',
+                }]
+        };
+
+        await connector.placeOrders(request);
+
+        const expected = `[{"symbol":"mock-groupusdt","size":"10.00000000","price":"10.00000000","side":"BUY","type":"LIMIT"}]`
+
+        expect(ax.post).toHaveBeenLastCalledWith(
+            expect.stringContaining(encodeURIComponent(expected)),
+            {},
+            { "headers": { "Content-Type": "application/json", "X-Bitget-APIKEY": "9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5" } }
+        );
+
+    });
+
+    it.skip('Can handle placeOrders(sell) action', async () => {
+
+        connector = new BitgetSpotPrivateConnector(
+            mockGroup,
+            mockConfig,
+            <any>{
+                key: '9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5',
+                secret: '448183b253bf1a5cebca0b7a09f75490325c5b0a876410f16092f9e716c6ebef',
+            },
+        );
+
+        const ax: any = axios;
+
+        const request: BatchOrdersRequest = {
+            event: 'BatchOrdersRequest',
+            timestamp: new Date().getTime(),
+            orders: [
+                {
+                    connectorType: 'Bitget',
+                    symbol: getSklSymbol(mockGroup, mockConfig),
+                    size: 10,
+                    price: 10,
+                    side: 'Sell',
+                    type: 'Limit',
+                }]
+        };
+
+        await connector.placeOrders(request);
+
+        const expected = `[{"symbol":"mock-groupusdt","size":"10.00000000","price":"10.00000000","side":"SELL","type":"LIMIT"}]`
+
+        expect(ax.post).toHaveBeenLastCalledWith(
+            expect.stringContaining(encodeURIComponent(expected)),
+            {},
+            { "headers": { "Content-Type": "application/json", "X-Bitget-APIKEY": "9e5a95533ff8e88a05bcde7fcf79d9fdf54ca0c5" } }
+        );
+
+    });
+});

--- a/Bitget (dziabko)/bitget-spot.ts
+++ b/Bitget (dziabko)/bitget-spot.ts
@@ -1,0 +1,26 @@
+import {
+    ConnectorConfiguration,
+    ConnectorGroup,
+    Side,
+} from '../../types';
+
+export type BitgetSide = 'BUY' | 'SELL' | undefined
+
+export const BitgetSideMap: { [key: string]: Side } = {
+    'buy': 'Buy',
+    'sell': 'Sell'
+}
+
+export const BitgetStringSideMap: { [key: string]: Side } = {
+    'BUY': 'Buy',
+    'SELL': 'Sell'
+}
+
+export const BitgetInvertedSideMap: { [key: string]: BitgetSide } = {
+    'Buy': 'BUY',
+    'Sell': 'SELL'
+}
+
+export const getBitgetSymbol = (symbolGroup: ConnectorGroup, connectorConfig: ConnectorConfiguration): string => {
+    return `${symbolGroup.name}${connectorConfig.quoteAsset}`
+}

--- a/Bitget (dziabko)/index.js
+++ b/Bitget (dziabko)/index.js
@@ -1,0 +1,30 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.main = main;
+const bitget_spot_public_connector_1 = require("./bitget-spot-public-connector");
+const bitget_spot_datahandler_1 = require("./bitget-spot-datahandler");
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+function main() {
+    return __awaiter(this, void 0, void 0, function* () {
+        console.log("Hello, world!");
+        // var a = new Serializable[];
+        const bitgetConnector = new bitget_spot_public_connector_1.BitgetSpotPublicConnector();
+        // Pass serializable MessageChannel to the connector and connect to the Bitget's public websocket
+        bitgetConnector.connect(bitget_spot_datahandler_1.onMessage);
+        // Wait 5 seconds for the connection to be established, and for the handlers to store some data
+        yield delay(5000);
+        console.log("End!");
+    });
+}
+main();

--- a/Bitget (dziabko)/index.ts
+++ b/Bitget (dziabko)/index.ts
@@ -1,5 +1,7 @@
-import { BitgetSpotPublicConnector } from "./bitget-spot-public-connector";
+import { BitgetFuturesPublicConnector } from "./bitget-futures-public-connector";
 import { onMessage } from "./bitget-spot-datahandler";
+import 'dotenv/config';
+import { BitgetFuturesPrivateConnector } from "./bitget-futures-private-connector";
 
 function delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -9,13 +11,18 @@ export async function main() {
     console.log("Hello, world!");
     // var a = new Serializable[];
 
-    const bitgetConnector = new BitgetSpotPublicConnector()
+    // const bitgetConnector = new BitgetSpotPublicConnector()
 
     // Pass serializable MessageChannel to the connector and connect to the Bitget's public websocket
-    bitgetConnector.connect(onMessage)
+    // bitgetConnector.connect(onMessage)
 
     // Wait 5 seconds for the connection to be established, and for the handlers to store some data
+    // await delay(5000);
+
+    const bitgetConnector = new BitgetFuturesPrivateConnector()
+    bitgetConnector.connect(onMessage)
     await delay(5000);
+
 
     console.log("End!");
 }

--- a/Bitget (dziabko)/index.ts
+++ b/Bitget (dziabko)/index.ts
@@ -1,0 +1,23 @@
+import { BitgetSpotPublicConnector } from "./bitget-spot-public-connector";
+import { onMessage } from "./bitget-spot-datahandler";
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function main() {
+    console.log("Hello, world!");
+    // var a = new Serializable[];
+
+    const bitgetConnector = new BitgetSpotPublicConnector()
+
+    // Pass serializable MessageChannel to the connector and connect to the Bitget's public websocket
+    bitgetConnector.connect(onMessage)
+
+    // Wait 5 seconds for the connection to be established, and for the handlers to store some data
+    await delay(5000);
+
+    console.log("End!");
+}
+
+main();

--- a/Bitget (dziabko)/package.json
+++ b/Bitget (dziabko)/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "bitgetconnector",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "dziabko",
+  "license": "ISC",
+  "description": ""
+}

--- a/Bitget (dziabko)/package.json
+++ b/Bitget (dziabko)/package.json
@@ -15,6 +15,9 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@types/crypto-js": "^4.2.2"
+    "@types/crypto-js": "^4.2.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "typescript": "^5.6.3"
   }
 }

--- a/Bitget (dziabko)/package.json
+++ b/Bitget (dziabko)/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node test.js"
   },
   "author": "dziabko",
   "license": "ISC",

--- a/Bitget (dziabko)/package.json
+++ b/Bitget (dziabko)/package.json
@@ -7,5 +7,14 @@
   },
   "author": "dziabko",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "bitget-api-node-sdk": "^2.1.4",
+    "crypto-js": "^4.2.0",
+    "dotenv": "^16.4.5",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/crypto-js": "^4.2.2"
+  }
 }

--- a/Bitget (dziabko)/test.ts
+++ b/Bitget (dziabko)/test.ts
@@ -1,0 +1,95 @@
+import { BitgetFuturesPublicConnector } from "./bitget-futures-public-connector";
+import { onMessage } from "./bitget-datahandler";
+import 'dotenv/config';
+import { BitgetFuturesPrivateConnector } from "./bitget-futures-private-connector";
+import CryptoJS from 'crypto-js';
+import * as BitgetApi from "bitget-api-node-sdk";
+// import WebSocketServer from 'ws';
+import { WebSocket } from 'ws';
+import * as Types from "./types"
+
+
+
+
+import axios, { AxiosStatic } from 'axios';
+import { connected } from "process";
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+
+class ListennerObj extends BitgetApi.Listenner{
+    reveice(message: string){
+        console.info('>>>'+message);
+    }
+}
+
+
+function handleMessage(data: string): void {
+    const message = JSON.parse(data);
+    if (message.event == 'login') {
+        console.log("LOGGED IN");
+    } else if (message.event == 'subscribe') {
+        console.log("SUBSCRIBED TO: ", message);
+    }else if (message.event == 'error') {
+        console.log("ERROR: ", message);
+    } else if (message.action == 'snapshot') {  // If the message is a SUSDT-FUTURES order
+        console.log("SNAPSHOT: ", message);
+    } else {
+        console.log("Unknown event: ", message);
+    }
+}
+
+
+export async function main() {
+    console.log("Hello, world!");
+
+    const bitgetConnector = new BitgetFuturesPrivateConnector()
+    bitgetConnector.connect(onMessage)
+
+    const order1: Types.FuturesLimitOrderRequest = {
+        size: "0.004",
+        side: "buy",
+        orderType: "limit",
+        force: "gtc",
+        price: "24000",
+    }
+    const order2: Types.FuturesLimitOrderRequest = {
+        size: "0.002",
+        side: "buy",
+        orderType: "limit",
+        force: "gtc",
+        price: "25000",
+    }
+    const batchOrder: Types.BatchFuturesLimitOrdersRequest = {
+        symbol: 'SBTCSUSDT',
+        productType: "SUSDT-FUTURES",
+        marginMode: "crossed",
+        marginCoin: "SUSDT",
+        orderList: [order1, order2]
+    }
+
+    console.log(JSON.stringify(batchOrder));
+
+    // Place 2 SUSDT-FUTURES limit orders on the SBTCUSDT market
+    await delay(6000);
+    bitgetConnector.placeOrders(batchOrder);
+
+    const openOrderRequest: Types.OpenOrdersRequest = {
+        productType: "SUSDT-FUTURES",
+        symbol: "SBTCSUSDT",
+    }
+
+    // Get all active orders
+    const orderStatusUpdate = await bitgetConnector.getCurrentActiveOrders(openOrderRequest);
+    // Ensure that there is only 1 active order
+
+    console.log("ORDER STATUS: ", orderStatusUpdate);
+
+    await bitgetConnector.stop(openOrderRequest)
+
+    console.log("End!");
+}
+
+main();

--- a/Bitget (dziabko)/test.ts
+++ b/Bitget (dziabko)/test.ts
@@ -1,4 +1,4 @@
-import { BitgetSpotPublicConnector } from "./bitget-futures-public-connector";
+import { BitgetFuturesPublicConnector } from "./bitget-futures-public-connector";
 import { onMessage } from "./bitget-datahandler";
 import 'dotenv/config';
 import { BitgetFuturesPrivateConnector } from "./bitget-futures-private-connector";
@@ -44,8 +44,6 @@ function handleMessage(data: string): void {
 
 
 export async function main() {
-    console.log("Hello, world!");
-
     const bitgetConnector = new BitgetFuturesPrivateConnector()
     bitgetConnector.connect(onMessage)
 

--- a/Bitget (dziabko)/test.ts
+++ b/Bitget (dziabko)/test.ts
@@ -12,7 +12,7 @@ import * as Types from "./types"
 
 
 import axios, { AxiosStatic } from 'axios';
-import { connected } from "process";
+import { connected, exit } from "process";
 
 function delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -160,10 +160,12 @@ export async function main() {
     
     // Verify the balance change of the account with closing the open orders (We're assuming we used at least 100USDT on both the open orders)
     if (balanceResp.baseBalance - balanceResp2.baseBalance < 100) {
-        console.log("Balance should have inccreased by at least 100USDT after deleting all open orders");
+        console.log("Balance should have increased by at least 100USDT after deleting all open orders");
     }
 
     await bitgetConnector.stop(openOrderRequest)
+    console.log("Stopped the websocket feed");
+    exit(0);
 }
 
 main();

--- a/Bitget (dziabko)/tsconfig.json
+++ b/Bitget (dziabko)/tsconfig.json
@@ -1,0 +1,110 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/Bitget (dziabko)/types.d.ts
+++ b/Bitget (dziabko)/types.d.ts
@@ -106,5 +106,245 @@ export interface channelRequest {
             channel: "ticker" | "trade",
             instId: string,
         }];
+}
 
+export interface BitgetSocketMessage{
+    event: string;
+    code: number;
+    msg: string;
+}
+
+export interface BitgetSnapshotData {
+    accBaseVolume: string,
+    cTime: string,
+    clientOId: string,
+    feeDetail: [{
+            feeCoin: string,
+            fee: string
+        }],
+    fillFee: string,
+    fillFeeCoin: string,
+    fillNotionalUsd: string,
+    fillPrice: string,
+    baseVolume: string,
+    fillTime: string,
+    force: string,
+    instId: string,
+    leverage: string,
+    marginCoin: string,
+    marginMode: string,
+    notionalUsd: string,
+    orderId: string,
+    orderType: string,
+    pnl: string,
+    posMode: string,
+    posSide: string,
+    price: string,
+    priceAvg: string,
+    reduceOnly: string,
+    stpMode: string,
+    side: string,
+    size: string,
+    enterPointSource: string,
+    status: string,
+    tradeScope: string,
+    tradeId: string,
+    tradeSide: string,
+    uTime: string
+}
+
+export interface BitgetSnapshot {
+    action: string,
+    arg: {
+        instType: string,
+        channel: string,
+        instId: string,
+    },
+    data: BitgetSnapshotData[],
+}
+
+export interface LoginResponse {
+    event: string,
+    code: string,
+    msg: string,
+}
+
+
+export interface BitgetAccountSnapshot {
+    action: string,
+    arg: {
+        instType: string,
+        channel: string,
+        coin: string,
+    },
+    data: BitgetAccountBalanceData[],
+}
+export interface BitgetAccountBalanceData {
+    marginCoin: string,
+    frozen: string,
+    available: string,
+    maxOpenPosAvailable: string,
+    maxTransferOut: string,
+    equity: string,
+    usdtEquity: string,
+    timestamp: string,
+}
+
+export interface BatchFuturesLimitOrdersRequest {
+    symbol: string,
+    productType: "USDT-FUTURES" | "COIN-FUTURES" | "USDC-FUTURES" | "SUSDT-FUTURES" | "SCOIN-FUTURUES" | "SUSDC-FUTURES",
+    marginMode: "crossed" | "isolated",
+    marginCoin: string,
+    orderList: FuturesLimitOrderRequest[],
+}
+
+export interface FuturesLimitOrderRequest {
+    size: string,
+    side: "buy" | "sell",
+    orderType: "limit" | "market",
+    force: "gtc" | "post_only" | "ioc" | "fok",
+    price: string,
+}
+
+export interface FuturesLimitOrderResponse {
+    code: string,
+    msg: string,
+    requestTime: number,
+    data: {
+        clientOid: string,
+        orderId: string,
+    }
+}
+
+export interface BatchCancelOrdersRequest {
+    orderList: CancelOrdersRequest[],
+}
+
+export interface CancelOrdersRequest {
+    symbol: string,
+    productType: string,
+    marginCoin: string,
+    orderId: string,
+    clientOid: string,
+}
+
+
+export interface ActiveOrder {
+    symbol: string,
+    size: string,
+    orderId: string,
+    clientOid: string,
+    baseVolume: string,
+    fee: string,
+    price: string,
+    priceAvg: string,
+    status: string,
+    side: string,
+    force: string,
+    totalProfits: string,
+    posSide: string,
+    marginCoin: string,
+    quoteVolume: string,
+    leverage: string,
+    marginMode: string,
+    enterPointSource: string,
+    tradeSide: string,
+    posMode: string,
+    orderType: string,
+    orderSource: string,
+    presetStopSurplusPrice: string,
+    presetStopLossPrice: string,
+    reduceOnly: string,
+    cTime: string,
+    uTime: string
+}
+
+export interface ActiveOrdersResponse {
+    code: string,
+    data: {
+        entrustedList: ActiveOrder[],
+        endId: string,
+    }
+    msg: string,
+    requestTime: string
+}
+
+export interface OpenOrdersRequest {
+    productType: string,
+    symbol: string,
+}
+
+export interface OrderStatusUpdate {
+    event: string,
+    symbol: string,
+    size: string,
+    orderId: string,
+    clientOid: string,
+    baseVolume?: string,
+    fee: string,
+    price: number,
+    priceAvg: string,
+    status: string,
+    side: string,
+    notional: number,
+    force: string,
+    totalProfits: string,
+    posSide: string,
+    marginCoin: string,
+    quoteVolume: string,
+    leverage: string,
+    marginMode: string,
+    enterPointSource: string,
+    tradeSide: string,
+    posMode: string,
+    orderType: string,
+    orderSource: string,
+    presetStopSurplusPrice: string,
+    presetStopLossPrice: string,
+    reduceOnly: string,
+    cTime: string,
+    uTime: string
+}
+
+export interface BalanceRequest {
+    productType: string
+}
+
+export interface AccountResponse {
+    code: string,
+    data: [
+        {
+            marginCoin: string,
+            locked: string,
+            available: string,
+            crossedMaxAvailable: string,
+            isolatedMaxAvailable: string,
+            maxTransferOut: string,
+            accountEquity: string,
+            usdtEquity: string,
+            btcEquity: string,
+            crossedRiskRate: string,
+            unrealizedPL: string,
+            coupon: string,
+            unionTotalMagin: string,
+            unionAvailable: string,
+            unionMm: string,
+            assetList: [
+                {
+                    coin: string,
+                    balance: string,
+                }
+            ]
+        }
+    ],
+    msg: string,
+    requestTime: string,
+}
+
+export interface BalanceResponse {
+    event: string,
+    symbol: string,
+    baseBalance: number,
+    inventory: number,
+    timestamp: string,
 }

--- a/Bitget (dziabko)/types.d.ts
+++ b/Bitget (dziabko)/types.d.ts
@@ -1,0 +1,110 @@
+export type Serializable = string | object
+export type SklEvent = "Trade" | "TopOfBook" | "Ticker" | "Version" | "Unsubscribe" | "OrderStatusUpdate" | "AllBalances"
+export type SklSupportedConnectors = "MEXC" | "Coinbase" | "Deribit" | "Bitget"
+
+export type SklSide = "Buy" | "Sell"
+
+
+
+export interface BasicSklNotificationProps {
+    event: SklEvent,
+    connectorType: SklSupportedConnectors
+    symbol: string,
+    timestamp: number,
+}
+
+export interface BitgetEventData { 
+    action: string,
+    arg: {
+        instType: string;
+        channel: string;
+        instId: string;
+    },
+    data: string[][],
+    ts: number,
+}
+// export interface BitgetEventData { 
+//     method: string
+//     id?: SklEvent
+//     result?: JSON
+//     params: { 
+//         id?: SklEvent
+//         channel?: string
+//         data: BitgetTicker | BitgetTopOfBook | BitgetTrade 
+//     } 
+// }
+
+export type Spread = [string, number, number]
+
+export interface BitgetTopOfBook {
+    prev_change_id: number | null // Doesn't exists for first notification
+    type: 'snapshot' | 'change';
+    timestamp: number;
+    instrument_name: string;
+    change_id: number;
+    // Array of arrays: [status, price, amount] - status [new, change or delete.]
+    bids: Spread[];
+    asks: Spread[];
+}
+
+export interface SklTrade extends BasicSklNotificationProps {
+    price: number,
+    size: number,
+    side: SklSide,
+}
+
+
+export interface BitgetTrade {
+    instType: string;  // Instrument Type
+    channel: string;  // Channel name
+    instId: string; // Instrument ID
+    timestamp: number;  // Trade Unix timestamp in ms
+    price: string;  // Trade price
+    size: string;  // Trade size
+    side: string; // Trade side
+
+    // action: string;
+    // arg: {
+    //     instType: string;
+    //     channel: string;
+    //     instId: string;
+    // };
+    // data: string[];
+    // ts: number;
+}
+
+export interface BitgetTicker {
+    action: string;
+    arg: {
+        instType: string;
+        channel: string;
+        instId: string;
+    };
+    data: [{
+        instId: string;
+        last: string;
+        price_change: string;
+        open24h: string;
+        high24h: string;
+        low24h: string;
+        bestBid: string;
+        bestAsk: string;
+        baseVolume: string;
+        quoteVolume: string;
+        ts: number;
+        labeId: string;
+        openUtc: string;
+        chgUTC: string;
+        bidSz: string;
+        askSz: string; 
+    }];
+}
+
+export interface channelRequest {
+    args: string[{
+            instType: "SP" | "MC", // SP - Spot, MC - Contract/futures
+            channel: "ticker" | "trade",
+            instId: string,
+        }];
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,96 @@
   "packages": {
     "": {
       "dependencies": {
+        "@bitmartexchange/bitmart-node-sdk-api": "^2.1.0",
         "ws": "^8.18.0"
       },
       "devDependencies": {
-        "@types/node": "^22.7.5"
+        "@types/node": "^22.7.5",
+        "ts-node": "^10.9.2"
       }
+    },
+    "node_modules/@bitmartexchange/bitmart-node-sdk-api": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@bitmartexchange/bitmart-node-sdk-api/-/bitmart-node-sdk-api-2.1.0.tgz",
+      "integrity": "sha512-mPHMXpk0KIJ5W78lprVLBMiva2qf3QCRCx+B/K84EUAzCNW+N4CBpg43nrm8Nw5GmlMQsuziUPu1OLBJKdomig==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.3",
+        "ws": "^8.13"
+      },
+      "engines": {
+        "node": ">=12.22.12",
+        "npm": ">=6.14.13"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.7.5",
@@ -21,10 +106,232 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
     },
@@ -46,6 +353,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "dependencies": {
+    "@bitmartexchange/bitmart-node-sdk-api": "^2.1.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {
-    "@types/node": "^22.7.5"
+    "@types/node": "^22.7.5",
+    "ts-node": "^10.9.2"
   }
 }


### PR DESCRIPTION
### Bitget Connector Documentation
- Implemented BitgetFuturesPrivateConnector & BitgetSpotPublicConnector
- The connectors implement the logic behind connecting to and handling the public/private APIs and Websocket connections to the Bitget exchange
- In both connectors, we can subscribe to any arbitrary channel configured by the user in the constructor through channelArguments, and have data handlers for incoming streams
- BitgetFuturesPublicConnector includes handling & serializing trades, and orders
- BitgetFuturesPrivateConnector includes appropriate authentication, subscription to private websocket channels, logic to handle new orders, and account balances, placing orders in batch, and appropriate REST API using signatures for private account information/data

### Installation & Testing
- Bitget does not [provide a testnet or demo trading on their spot](https://www.bitget.fit/api-doc/common/demotrading/restapi), so I had to resort to creating the connector to the futures (SUSDT)
- Please get demo SUSDT tokens for the test (although it will work with other demo tokens, alter the BitgetFuturesPrivateConnector.channelArguments for the appropriate channels or tokens
- After creating your keys from [https://www.bitget.com/account/newapi](https://www.bitget.com/account/newapi) set your API_KEY, SECRET_KEY, and PASSPHRASE in your .env file in the same folder

From the './connectorTrial/Bitget (dziabko)' directory
`npx tsc`
`npm run start`
